### PR TITLE
feat(ui): ErrorBoundary, EmptyState y sección Spotify Connect (#19, #20, #21)

### DIFF
--- a/frontend/src/components/layout/ErrorBoundary.test.tsx
+++ b/frontend/src/components/layout/ErrorBoundary.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ErrorBoundary } from './ErrorBoundary'
+
+function Bomb({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('test error')
+  return <p>OK</p>
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('ErrorBoundary', () => {
+  it('renders children when there is no error', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow={false} />
+      </ErrorBoundary>,
+    )
+    expect(screen.getByText('OK')).toBeInTheDocument()
+  })
+
+  it('renders fallback when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow />
+      </ErrorBoundary>,
+    )
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reintentar/i })).toBeInTheDocument()
+  })
+
+  it('resets the boundary when "Reintentar" is clicked', () => {
+    const { rerender } = render(
+      <ErrorBoundary>
+        <Bomb shouldThrow />
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+
+    rerender(
+      <ErrorBoundary>
+        <Bomb shouldThrow={false} />
+      </ErrorBoundary>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /reintentar/i }))
+
+    expect(screen.getByText('OK')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/layout/ErrorBoundary.tsx
+++ b/frontend/src/components/layout/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { Button } from '@/components/ui'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, info)
+  }
+
+  reset = () => this.setState({ hasError: false })
+
+  override render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          role="alert"
+          className="flex flex-col items-center justify-center gap-4 p-8 text-center"
+        >
+          <p className="text-lg font-medium text-gray-800">Algo salió mal.</p>
+          <Button variant="secondary" onClick={this.reset}>
+            Reintentar
+          </Button>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/frontend/src/components/layout/index.ts
+++ b/frontend/src/components/layout/index.ts
@@ -1,3 +1,4 @@
 export { AppShell } from './AppShell'
 export { Header } from './Header'
 export { Footer } from './Footer'
+export { ErrorBoundary } from './ErrorBoundary'

--- a/frontend/src/components/ui/EmptyState.test.tsx
+++ b/frontend/src/components/ui/EmptyState.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { EmptyState } from './EmptyState'
+import { Button } from './Button'
+
+describe('EmptyState', () => {
+  it('renders the title', () => {
+    render(<EmptyState title="Sin resultados" />)
+    expect(screen.getByText('Sin resultados')).toBeInTheDocument()
+  })
+
+  it('renders the description when provided', () => {
+    render(<EmptyState title="Sin resultados" description="Prueba con otro filtro." />)
+    expect(screen.getByText('Prueba con otro filtro.')).toBeInTheDocument()
+  })
+
+  it('renders the CTA slot', () => {
+    render(
+      <EmptyState
+        title="Sin resultados"
+        cta={<Button>Añadir algo</Button>}
+      />,
+    )
+    expect(screen.getByRole('button', { name: 'Añadir algo' })).toBeInTheDocument()
+  })
+
+  it('renders the illustration slot', () => {
+    render(
+      <EmptyState
+        title="Sin resultados"
+        illustration={<img src="/empty.svg" alt="vacío" />}
+      />,
+    )
+    expect(screen.getByAltText('vacío')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react'
+
+export interface EmptyStateProps {
+  title: string
+  description?: string
+  illustration?: ReactNode
+  cta?: ReactNode
+}
+
+export function EmptyState({ title, description, illustration, cta }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
+      {illustration && <div aria-hidden="true">{illustration}</div>}
+      <p className="text-lg font-semibold text-gray-800">{title}</p>
+      {description && <p className="text-sm text-gray-500">{description}</p>}
+      {cta && <div>{cta}</div>}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -30,3 +30,6 @@ export type { ToastProviderProps } from './Toast'
 
 export { useToast } from '../../lib/useToast'
 export type { Toast, ToastType } from '../../lib/ToastContextValue'
+
+export { EmptyState } from './EmptyState'
+export type { EmptyStateProps } from './EmptyState'

--- a/frontend/src/pages/Connect/Spotify.tsx
+++ b/frontend/src/pages/Connect/Spotify.tsx
@@ -1,0 +1,18 @@
+import { Button } from '@/components/ui'
+
+export function SpotifyConnect() {
+  return (
+    <section aria-labelledby="spotify-connect-heading" className="flex flex-col gap-4 p-8">
+      <h2 id="spotify-connect-heading" className="text-xl font-semibold text-gray-900">
+        Conectar Spotify
+      </h2>
+      <p className="text-sm text-gray-600">
+        Inicia sesión con tu cuenta de Spotify para que podamos leer tus playlists y álbumes
+        guardados. Serás redirigido a Spotify para autorizar el acceso.
+      </p>
+      <div>
+        <Button>Conectar con Spotify</Button>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -1,1 +1,1 @@
-export {}
+export { SpotifyConnect } from './Connect/Spotify'


### PR DESCRIPTION
## Summary

- **#19** — `ErrorBoundary` en `components/layout/` con fallback accesible (`role="alert"`) y botón "Reintentar" que resetea el boundary
- **#20** — `EmptyState` en `components/ui/` con slots para `title`, `description`, `illustration` y `cta`
- **#21** — `pages/Connect/Spotify.tsx` con sección estática: título, descripción del flujo OAuth y botón "Conectar con Spotify" accesible vía `aria-labelledby`

## Test plan

- [ ] 89 tests pasan (`pnpm exec vitest run` en `frontend/`)
- [ ] `ErrorBoundary`: renderiza hijos sin error, muestra fallback al lanzar, resetea al hacer clic en "Reintentar"
- [ ] `EmptyState`: renderiza título, descripción, slot CTA, slot ilustración
- [ ] `SpotifyConnect`: botón visible y accesible (sin handler funcional, per spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)