### PR TITLE
feat(auth): Spotify OAuth hook + YouTube Music headers UI

### DIFF
--- a/frontend/src/features/auth/useSpotifyAuth.test.tsx
+++ b/frontend/src/features/auth/useSpotifyAuth.test.tsx
@@ -1,0 +1,54 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { server } from '@/test/msw/server';
+import { spotifyAuthErrorHandler } from '@/test/msw/handlers';
+import { useSpotifyAuth } from './useSpotifyAuth';
+
+let assignSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  assignSpy = vi.fn();
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, assign: assignSpy },
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useSpotifyAuth', () => {
+  it('starts in idle state', () => {
+    const { result } = renderHook(() => useSpotifyAuth());
+    expect(result.current.state).toBe('idle');
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it('redirects to the auth URL on success', async () => {
+    const { result } = renderHook(() => useSpotifyAuth());
+
+    await act(async () => {
+      result.current.connect();
+    });
+
+    expect(result.current.state).toBe('success');
+    expect(assignSpy).toHaveBeenCalledWith('http://127.0.0.1:8888/auth/spotify');
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it('sets error state and message on HTTP error', async () => {
+    server.use(spotifyAuthErrorHandler);
+
+    const { result } = renderHook(() => useSpotifyAuth());
+
+    await act(async () => {
+      result.current.connect();
+    });
+
+    expect(result.current.state).toBe('error');
+    expect(result.current.errorMessage).toBe('Error de configuración');
+    expect(assignSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/auth/useSpotifyAuth.ts
+++ b/frontend/src/features/auth/useSpotifyAuth.ts
@@ -1,0 +1,42 @@
+import { useCallback, useState } from 'react';
+import { http, HttpError } from '@/lib/http';
+
+export type AuthState = 'idle' | 'starting' | 'success' | 'error';
+
+export interface UseSpotifyAuthResult {
+  state: AuthState;
+  errorMessage: string | null;
+  connect: () => void;
+}
+
+export function useSpotifyAuth(): UseSpotifyAuthResult {
+  const [state, setState] = useState<AuthState>('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const connect = useCallback(() => {
+    setState('starting');
+    setErrorMessage(null);
+
+    http
+      .post<{ url: string }>('/auth/spotify')
+      .then(({ url }) => {
+        setState('success');
+        window.location.assign(url);
+      })
+      .catch((err: unknown) => {
+        setState('error');
+        if (err instanceof HttpError) {
+          const body = err.body as Record<string, unknown> | null;
+          setErrorMessage(
+            typeof body?.message === 'string'
+              ? body.message
+              : `Error al conectar con Spotify (${err.status})`,
+          );
+        } else {
+          setErrorMessage('No se pudo conectar. Comprueba tu conexión e inténtalo de nuevo.');
+        }
+      });
+  }, []);
+
+  return { state, errorMessage, connect };
+}

--- a/frontend/src/pages/Connect/Spotify.test.tsx
+++ b/frontend/src/pages/Connect/Spotify.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { server } from '@/test/msw/server';
+import { spotifyAuthErrorHandler } from '@/test/msw/handlers';
+import { SpotifyConnect } from './Spotify';
+
+let assignSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  assignSpy = vi.fn();
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, assign: assignSpy },
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('SpotifyConnect', () => {
+  it('renders the connect button', () => {
+    render(<SpotifyConnect />);
+    expect(screen.getByRole('button', { name: /conectar con spotify/i })).toBeInTheDocument();
+  });
+
+  it('redirects to the auth URL on success', async () => {
+    render(<SpotifyConnect />);
+    fireEvent.click(screen.getByRole('button', { name: /conectar con spotify/i }));
+
+    await waitFor(() => {
+      expect(assignSpy).toHaveBeenCalledWith('http://127.0.0.1:8888/auth/spotify');
+    });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows an error message on failure', async () => {
+    server.use(spotifyAuthErrorHandler);
+    render(<SpotifyConnect />);
+    fireEvent.click(screen.getByRole('button', { name: /conectar con spotify/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Error de configuración');
+    expect(assignSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/Connect/Spotify.tsx
+++ b/frontend/src/pages/Connect/Spotify.tsx
@@ -1,6 +1,9 @@
-import { Button } from '@/components/ui'
+import { Button, FieldError } from '@/components/ui';
+import { useSpotifyAuth } from '@/features/auth/useSpotifyAuth';
 
 export function SpotifyConnect() {
+  const { state, errorMessage, connect } = useSpotifyAuth();
+
   return (
     <section aria-labelledby="spotify-connect-heading" className="flex flex-col gap-4 p-8">
       <h2 id="spotify-connect-heading" className="text-xl font-semibold text-gray-900">
@@ -10,9 +13,20 @@ export function SpotifyConnect() {
         Inicia sesión con tu cuenta de Spotify para que podamos leer tus playlists y álbumes
         guardados. Serás redirigido a Spotify para autorizar el acceso.
       </p>
-      <div>
-        <Button>Conectar con Spotify</Button>
+      <div className="flex flex-col gap-2">
+        <div>
+          <Button
+            onClick={connect}
+            disabled={state === 'starting' || state === 'success'}
+            loading={state === 'starting'}
+          >
+            Conectar con Spotify
+          </Button>
+        </div>
+        {state === 'error' && errorMessage && (
+          <FieldError>{errorMessage}</FieldError>
+        )}
       </div>
     </section>
-  )
+  );
 }

--- a/frontend/src/pages/Connect/YTMusic.test.tsx
+++ b/frontend/src/pages/Connect/YTMusic.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { YTMusicConnect } from './YTMusic';
+
+describe('YTMusicConnect', () => {
+  it('renders the section heading', () => {
+    render(<YTMusicConnect />);
+    expect(screen.getByRole('heading', { name: /conectar youtube music/i })).toBeInTheDocument();
+  });
+
+  it('renders a labelled textarea', () => {
+    render(<YTMusicConnect />);
+    expect(screen.getByLabelText(/headers del navegador/i)).toBeInTheDocument();
+  });
+
+  it('renders the connect button', () => {
+    render(<YTMusicConnect />);
+    expect(screen.getByRole('button', { name: /conectar con youtube music/i })).toBeInTheDocument();
+  });
+
+  it('button is disabled when textarea is empty', () => {
+    render(<YTMusicConnect />);
+    expect(screen.getByRole('button', { name: /conectar con youtube music/i })).toBeDisabled();
+  });
+
+  it('button is enabled when textarea has content', () => {
+    render(<YTMusicConnect />);
+    fireEvent.change(screen.getByLabelText(/headers del navegador/i), {
+      target: { value: 'Authorization: Bearer token' },
+    });
+    expect(screen.getByRole('button', { name: /conectar con youtube music/i })).toBeEnabled();
+  });
+
+  it('help text references DevTools and Network', () => {
+    render(<YTMusicConnect />);
+    const section = screen.getByRole('region', { name: /conectar youtube music/i });
+    expect(section).toHaveTextContent(/devtools/i);
+    expect(section).toHaveTextContent(/network/i);
+  });
+});

--- a/frontend/src/pages/Connect/YTMusic.tsx
+++ b/frontend/src/pages/Connect/YTMusic.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { Button, Label, Textarea } from '@/components/ui';
+
+export function YTMusicConnect() {
+  const [headers, setHeaders] = useState('');
+
+  return (
+    <section aria-labelledby="ytmusic-connect-heading" className="flex flex-col gap-4 p-8">
+      <h2 id="ytmusic-connect-heading" className="text-xl font-semibold text-gray-900">
+        Conectar YouTube Music
+      </h2>
+      <p className="text-sm text-gray-600">
+        Para autenticar con YouTube Music necesitas capturar los headers de tu navegador:
+      </p>
+      <ol className="list-decimal list-inside space-y-1 text-sm text-gray-600">
+        <li>Abre YouTube Music en Chrome o Firefox.</li>
+        <li>Abre las DevTools (F12) y ve a la pestaña <strong>Network</strong>.</li>
+        <li>Recarga la página y filtra las peticiones por <code>browse</code>.</li>
+        <li>Haz clic en cualquier petición a <code>browse</code> y copia los headers de la sección <strong>Request Headers</strong>.</li>
+        <li>Pega los headers en el campo de abajo y pulsa «Conectar».</li>
+      </ol>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="ytmusic-headers">Headers del navegador</Label>
+        <Textarea
+          id="ytmusic-headers"
+          value={headers}
+          onChange={(e) => setHeaders(e.target.value)}
+          rows={8}
+          placeholder="Pega aquí los headers copiados de DevTools..."
+        />
+      </div>
+      <div>
+        <Button disabled={headers.trim().length === 0}>
+          Conectar con YouTube Music
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/test/msw/handlers.ts
+++ b/frontend/src/test/msw/handlers.ts
@@ -12,7 +12,9 @@ const migrationEvents = ws.link('*/api/migrate/:jobId/events');
 export const handlers = [
   http.get('*/api/health', () => HttpResponse.json({ ok: true })),
 
-  http.post('*/api/auth/spotify', () => HttpResponse.json({ ok: true })),
+  http.post('*/api/auth/spotify', () =>
+    HttpResponse.json({ url: 'http://127.0.0.1:8888/auth/spotify' }),
+  ),
 
   http.post('*/api/auth/ytmusic', () => HttpResponse.json({ ok: true })),
 
@@ -42,3 +44,8 @@ export const handlers = [
     }, 50);
   }),
 ];
+
+export const spotifyAuthErrorHandler = http.post(
+  '*/api/auth/spotify',
+  () => HttpResponse.json({ message: 'Error de configuración' }, { status: 500 }),
+);


### PR DESCRIPTION
## Summary

- Add `useSpotifyAuth` hook with `idle | starting | success | error` states that POSTs to `/api/auth/spotify` and redirects the browser to the returned URL
- Wire the hook to `SpotifyConnect`: button shows loading spinner while in-flight, disables on success, and surfaces an inline `FieldError` on failure
- Update MSW stub for `POST /api/auth/spotify` to return `{ url }` and export `spotifyAuthErrorHandler` for error-path test overrides
- Add `YTMusicConnect` component with a labelled `Textarea` for browser headers, a "Conectar" button (disabled until content is present), and step-by-step DevTools help text

## Closes

Closes #22, Closes #23

## Test plan

- [ ] `useSpotifyAuth`: idle → success path calls `window.location.assign` with the redirect URL
- [ ] `useSpotifyAuth`: idle → error path sets `errorMessage` from the HTTP response body
- [ ] `SpotifyConnect`: clicking the button shows loading state, then redirects on success
- [ ] `SpotifyConnect`: error response renders `FieldError` with the server message
- [ ] `YTMusicConnect`: heading, labelled textarea, and button all render accessibly
- [ ] `YTMusicConnect`: button disabled when textarea is empty; enabled when it has content
- [ ] `YTMusicConnect`: help text references DevTools and Network tab
- [ ] `pnpm exec vitest run` — all 101 tests pass
- [ ] `pnpm run lint` — 0 errors
- [ ] `pnpm exec tsc --noEmit` — clean