### PR TITLE
feat(library): selección de playlists/albums y barra Migrar

### DIFF
--- a/frontend/src/components/Library/SelectionSummary.test.tsx
+++ b/frontend/src/components/Library/SelectionSummary.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SelectionSummary } from './SelectionSummary';
+
+function renderComponent(playlistCount: number, albumCount: number, onMigrate = vi.fn()) {
+  return render(<SelectionSummary playlistCount={playlistCount} albumCount={albumCount} onMigrate={onMigrate} />);
+}
+
+describe('SelectionSummary', () => {
+  it('shows "Ningún elemento seleccionado" when both counts are zero', () => {
+    renderComponent(0, 0);
+    expect(screen.getByText(/ningún elemento seleccionado/i)).toBeInTheDocument();
+  });
+
+  it('shows playlist count in label', () => {
+    renderComponent(2, 0);
+    expect(screen.getByText(/2 playlists/i)).toBeInTheDocument();
+  });
+
+  it('shows album count in label', () => {
+    renderComponent(0, 3);
+    expect(screen.getByText(/3 álbumes/i)).toBeInTheDocument();
+  });
+
+  it('shows both counts when both are selected', () => {
+    renderComponent(1, 2);
+    const label = screen.getByText(/1 playlist.*2 álbumes|2 álbumes.*1 playlist/i);
+    expect(label).toBeInTheDocument();
+  });
+
+  it('disables the Migrar button when nothing is selected', () => {
+    renderComponent(0, 0);
+    expect(screen.getByRole('button', { name: /migrar/i })).toBeDisabled();
+  });
+
+  it('enables the Migrar button when there is a selection', () => {
+    renderComponent(1, 0);
+    expect(screen.getByRole('button', { name: /migrar/i })).not.toBeDisabled();
+  });
+
+  it('calls onMigrate when button is clicked', () => {
+    const onMigrate = vi.fn();
+    renderComponent(1, 1, onMigrate);
+    fireEvent.click(screen.getByRole('button', { name: /migrar/i }));
+    expect(onMigrate).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/Library/SelectionSummary.tsx
+++ b/frontend/src/components/Library/SelectionSummary.tsx
@@ -1,0 +1,25 @@
+import { Button } from '@/components/ui';
+
+export interface SelectionSummaryProps {
+  playlistCount: number;
+  albumCount: number;
+  onMigrate: () => void;
+}
+
+export function SelectionSummary({ playlistCount, albumCount, onMigrate }: SelectionSummaryProps) {
+  const isEmpty = playlistCount + albumCount === 0;
+
+  const parts: string[] = [];
+  if (playlistCount > 0) parts.push(`${playlistCount} playlist${playlistCount !== 1 ? 's' : ''}`);
+  if (albumCount > 0) parts.push(`${albumCount} álbum${albumCount !== 1 ? 'es' : ''}`);
+  const label = isEmpty ? 'Ningún elemento seleccionado' : `${parts.join(', ')} seleccionado${parts.length > 1 || playlistCount + albumCount > 1 ? 's' : ''}`;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-10 flex items-center justify-between border-t border-gray-200 bg-white px-4 py-3 shadow-md">
+      <span className="text-sm text-gray-600">{label}</span>
+      <Button onClick={onMigrate} disabled={isEmpty}>
+        Migrar
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/features/library/index.ts
+++ b/frontend/src/features/library/index.ts
@@ -1,1 +1,3 @@
 export { usePlaylists } from './usePlaylists';
+export { useAlbums } from './useAlbums';
+export { useSelection } from './useSelection';

--- a/frontend/src/features/library/useAlbums.test.ts
+++ b/frontend/src/features/library/useAlbums.test.ts
@@ -1,0 +1,35 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/msw/server';
+import { sampleAlbums } from '@/test/msw/fixtures';
+import { makeQueryWrapper } from '@/test/queryWrapper';
+import { useAlbums } from './useAlbums';
+
+describe('useAlbums', () => {
+  it('starts in loading state', () => {
+    const { result } = renderHook(() => useAlbums(), { wrapper: makeQueryWrapper() });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('returns album data on success', async () => {
+    const { result } = renderHook(() => useAlbums(), { wrapper: makeQueryWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(sampleAlbums);
+  });
+
+  it('returns empty array when server returns no albums', async () => {
+    server.use(http.get('*/api/albums', () => HttpResponse.json([])));
+    const { result } = renderHook(() => useAlbums(), { wrapper: makeQueryWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('sets isError on HTTP failure', async () => {
+    server.use(http.get('*/api/albums', () => HttpResponse.json({}, { status: 500 })));
+    const { result } = renderHook(() => useAlbums(), { wrapper: makeQueryWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/frontend/src/features/library/useAlbums.ts
+++ b/frontend/src/features/library/useAlbums.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { http } from '@/lib/http';
+import type { Album } from '@/types/api';
+
+export function useAlbums() {
+  return useQuery({
+    queryKey: ['albums'],
+    queryFn: () => http.get<Album[]>('/albums'),
+  });
+}

--- a/frontend/src/features/library/useSelection.test.ts
+++ b/frontend/src/features/library/useSelection.test.ts
@@ -1,0 +1,73 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useSelection } from './useSelection';
+
+const items = [
+  { id: 'a', name: 'Alpha' },
+  { id: 'b', name: 'Beta' },
+  { id: 'c', name: 'Gamma' },
+];
+const getId = (item: { id: string }) => item.id;
+
+describe('useSelection', () => {
+  it('starts with none selected', () => {
+    const { result } = renderHook(() => useSelection(items, getId));
+    expect(result.current.selectionState).toBe('none');
+    expect(result.current.selectedIds.size).toBe(0);
+  });
+
+  it('toggleAll selects all items → state becomes all', () => {
+    const { result } = renderHook(() => useSelection(items, getId));
+    act(() => result.current.toggleAll());
+    expect(result.current.selectionState).toBe('all');
+    expect(result.current.selectedIds.size).toBe(items.length);
+  });
+
+  it('after select all, deselecting one item → state becomes some (indeterminate)', () => {
+    const { result } = renderHook(() => useSelection(items, getId));
+    act(() => result.current.toggleAll());
+    act(() => result.current.toggle('a'));
+    expect(result.current.selectionState).toBe('some');
+    expect(result.current.selectedIds.has('a')).toBe(false);
+    expect(result.current.selectedIds.has('b')).toBe(true);
+  });
+
+  it('deselecting all remaining items → state becomes none', () => {
+    const { result } = renderHook(() => useSelection(items, getId));
+    act(() => result.current.toggleAll());
+    act(() => result.current.toggle('a'));
+    act(() => result.current.toggle('b'));
+    act(() => result.current.toggle('c'));
+    expect(result.current.selectionState).toBe('none');
+    expect(result.current.selectedIds.size).toBe(0);
+  });
+
+  it('toggleAll when all are selected deselects all → state becomes none', () => {
+    const { result } = renderHook(() => useSelection(items, getId));
+    act(() => result.current.toggleAll());
+    act(() => result.current.toggleAll());
+    expect(result.current.selectionState).toBe('none');
+    expect(result.current.selectedIds.size).toBe(0);
+  });
+
+  it('toggleAll with empty items list stays none', () => {
+    const { result } = renderHook(() => useSelection([], getId));
+    act(() => result.current.toggleAll());
+    expect(result.current.selectionState).toBe('none');
+  });
+
+  it('toggle adds an id when not selected', () => {
+    const { result } = renderHook(() => useSelection(items, getId));
+    act(() => result.current.toggle('b'));
+    expect(result.current.selectedIds.has('b')).toBe(true);
+    expect(result.current.selectionState).toBe('some');
+  });
+
+  it('toggle removes an id when already selected', () => {
+    const { result } = renderHook(() => useSelection(items, getId));
+    act(() => result.current.toggle('b'));
+    act(() => result.current.toggle('b'));
+    expect(result.current.selectedIds.has('b')).toBe(false);
+    expect(result.current.selectionState).toBe('none');
+  });
+});

--- a/frontend/src/features/library/useSelection.ts
+++ b/frontend/src/features/library/useSelection.ts
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+export type SelectionState = 'none' | 'some' | 'all';
+
+export interface UseSelectionResult {
+  selectedIds: Set<string>;
+  toggle: (id: string) => void;
+  toggleAll: () => void;
+  selectionState: SelectionState;
+}
+
+export function useSelection<T>(items: T[], getId: (item: T) => string): UseSelectionResult {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const toggle = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    setSelectedIds((prev) => {
+      if (prev.size === items.length && items.length > 0) {
+        return new Set();
+      }
+      return new Set(items.map(getId));
+    });
+  };
+
+  const selectionState: SelectionState =
+    selectedIds.size === 0
+      ? 'none'
+      : selectedIds.size === items.length
+        ? 'all'
+        : 'some';
+
+  return { selectedIds, toggle, toggleAll, selectionState };
+}

--- a/frontend/src/features/migrate/index.ts
+++ b/frontend/src/features/migrate/index.ts
@@ -1,0 +1,2 @@
+export { useMigrationSelection } from './useMigrationSelection';
+export type { MigrationSelection } from './useMigrationSelection';

--- a/frontend/src/features/migrate/useMigrationSelection.test.ts
+++ b/frontend/src/features/migrate/useMigrationSelection.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { useMigrationSelection } from './useMigrationSelection';
+
+describe('useMigrationSelection', () => {
+  it('returns isEmpty true and zero counts when both sets are empty', () => {
+    const result = useMigrationSelection(new Set(), new Set());
+    expect(result.isEmpty).toBe(true);
+    expect(result.total).toBe(0);
+    expect(result.playlistCount).toBe(0);
+    expect(result.albumCount).toBe(0);
+  });
+
+  it('counts playlists correctly', () => {
+    const result = useMigrationSelection(new Set(['pl_1', 'pl_2']), new Set());
+    expect(result.playlistCount).toBe(2);
+    expect(result.albumCount).toBe(0);
+    expect(result.total).toBe(2);
+    expect(result.isEmpty).toBe(false);
+  });
+
+  it('counts albums correctly', () => {
+    const result = useMigrationSelection(new Set(), new Set(['alb_1']));
+    expect(result.playlistCount).toBe(0);
+    expect(result.albumCount).toBe(1);
+    expect(result.total).toBe(1);
+    expect(result.isEmpty).toBe(false);
+  });
+
+  it('sums both when both have selections', () => {
+    const result = useMigrationSelection(new Set(['pl_1']), new Set(['alb_1', 'alb_2']));
+    expect(result.total).toBe(3);
+    expect(result.isEmpty).toBe(false);
+  });
+
+  it('passes through the sets by reference', () => {
+    const playlists = new Set(['pl_1']);
+    const albums = new Set(['alb_1']);
+    const result = useMigrationSelection(playlists, albums);
+    expect(result.selectedPlaylistIds).toBe(playlists);
+    expect(result.selectedAlbumIds).toBe(albums);
+  });
+});

--- a/frontend/src/features/migrate/useMigrationSelection.ts
+++ b/frontend/src/features/migrate/useMigrationSelection.ts
@@ -1,0 +1,24 @@
+export interface MigrationSelection {
+  playlistCount: number;
+  albumCount: number;
+  total: number;
+  isEmpty: boolean;
+  selectedPlaylistIds: Set<string>;
+  selectedAlbumIds: Set<string>;
+}
+
+export function useMigrationSelection(
+  selectedPlaylistIds: Set<string>,
+  selectedAlbumIds: Set<string>,
+): MigrationSelection {
+  const playlistCount = selectedPlaylistIds.size;
+  const albumCount = selectedAlbumIds.size;
+  return {
+    playlistCount,
+    albumCount,
+    total: playlistCount + albumCount,
+    isEmpty: playlistCount + albumCount === 0,
+    selectedPlaylistIds,
+    selectedAlbumIds,
+  };
+}

--- a/frontend/src/pages/Library/Albums.test.tsx
+++ b/frontend/src/pages/Library/Albums.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/msw/server';
+import { sampleAlbums } from '@/test/msw/fixtures';
+import { makeQueryWrapper } from '@/test/queryWrapper';
+import { Albums } from './Albums';
+
+function renderComponent(props: Partial<React.ComponentProps<typeof Albums>> = {}) {
+  return render(<Albums {...props} />, { wrapper: makeQueryWrapper() });
+}
+
+describe('Albums', () => {
+  it('shows skeleton rows while loading', () => {
+    renderComponent();
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+  });
+
+  it('shows error message and retry button on failure', async () => {
+    server.use(http.get('*/api/albums', () => HttpResponse.json({}, { status: 500 })));
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText(/no se pudieron cargar los álbumes/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /reintentar/i })).toBeInTheDocument();
+  });
+
+  it('shows EmptyState when no albums returned', async () => {
+    server.use(http.get('*/api/albums', () => HttpResponse.json([])));
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText(/no tienes álbumes guardados/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders album names and artists on success', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText(sampleAlbums[0].name)).toBeInTheDocument();
+    });
+    for (const album of sampleAlbums) {
+      expect(screen.getByText(album.name)).toBeInTheDocument();
+      expect(screen.getByText(album.artist)).toBeInTheDocument();
+    }
+  });
+
+  describe('selection', () => {
+    it('renders select-all checkbox when onToggleAll is provided', async () => {
+      renderComponent({ onToggleAll: vi.fn(), onToggle: vi.fn(), selectionState: 'none' });
+      await waitFor(() => expect(screen.getByText(sampleAlbums[0].name)).toBeInTheDocument());
+      expect(screen.getByRole('checkbox', { name: /seleccionar todos los álbumes/i })).toBeInTheDocument();
+    });
+
+    it('calls onToggleAll when select-all checkbox is clicked', async () => {
+      const onToggleAll = vi.fn();
+      renderComponent({ onToggleAll, onToggle: vi.fn(), selectionState: 'none' });
+      await waitFor(() => expect(screen.getByText(sampleAlbums[0].name)).toBeInTheDocument());
+      fireEvent.click(screen.getByRole('checkbox', { name: /seleccionar todos los álbumes/i }));
+      expect(onToggleAll).toHaveBeenCalledOnce();
+    });
+
+    it('select-all checkbox is checked when selectionState is all', async () => {
+      const ids = new Set(sampleAlbums.map((a) => a.spotifyId));
+      renderComponent({ onToggleAll: vi.fn(), onToggle: vi.fn(), selectedIds: ids, selectionState: 'all' });
+      await waitFor(() => expect(screen.getByText(sampleAlbums[0].name)).toBeInTheDocument());
+      const checkbox = screen.getByRole('checkbox', { name: /seleccionar todos los álbumes/i }) as HTMLInputElement;
+      expect(checkbox.checked).toBe(true);
+      expect(checkbox.indeterminate).toBe(false);
+    });
+
+    it('calls onToggle when a row checkbox is clicked', async () => {
+      const onToggle = vi.fn();
+      renderComponent({ onToggle, onToggleAll: vi.fn(), selectionState: 'none' });
+      await waitFor(() => expect(screen.getByText(sampleAlbums[0].name)).toBeInTheDocument());
+      const checkboxes = screen.getAllByRole('checkbox', { name: /seleccionar in rainbows/i });
+      fireEvent.click(checkboxes[0]);
+      expect(onToggle).toHaveBeenCalledWith(sampleAlbums[0].spotifyId);
+    });
+  });
+});

--- a/frontend/src/pages/Library/Albums.tsx
+++ b/frontend/src/pages/Library/Albums.tsx
@@ -1,0 +1,83 @@
+import { Button, EmptyState, List, ListItem, ListItemTrailing, Skeleton } from '@/components/ui';
+import { useAlbums } from '@/features/library/useAlbums';
+
+function AlbumSkeletons() {
+  return (
+    <div className="flex flex-col gap-3 p-4">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <Skeleton key={i} variant="text" height={24} />
+      ))}
+    </div>
+  );
+}
+
+export interface AlbumsProps {
+  selectedIds?: Set<string>;
+  onToggle?: (id: string) => void;
+  onToggleAll?: () => void;
+  selectionState?: 'none' | 'some' | 'all';
+}
+
+export function Albums({ selectedIds = new Set(), onToggle, onToggleAll, selectionState = 'none' }: AlbumsProps) {
+  const { data, isLoading, isError, refetch } = useAlbums();
+
+  if (isLoading) return <AlbumSkeletons />;
+
+  if (isError) {
+    return (
+      <div className="flex flex-col items-center gap-3 p-8 text-center">
+        <p className="text-sm text-red-600">No se pudieron cargar los álbumes.</p>
+        <Button onClick={() => refetch()}>Reintentar</Button>
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <EmptyState
+        title="No tienes álbumes guardados"
+        description="Conecta Spotify para ver tus álbumes aquí."
+      />
+    );
+  }
+
+  return (
+    <div>
+      {onToggleAll && (
+        <div className="flex items-center gap-3 px-4 py-2 border-b border-gray-200 bg-gray-50">
+          <input
+            type="checkbox"
+            aria-label="Seleccionar todos los álbumes"
+            checked={selectionState === 'all'}
+            ref={(el) => {
+              if (el) el.indeterminate = selectionState === 'some';
+            }}
+            onChange={onToggleAll}
+            className="h-4 w-4 rounded border-gray-300 text-blue-600"
+          />
+          <span className="text-xs text-gray-500">Seleccionar todos</span>
+        </div>
+      )}
+      <List selectedIds={[...selectedIds]} onSelect={onToggle}>
+        {data.map((album) => (
+          <ListItem key={album.spotifyId} id={album.spotifyId}>
+            {onToggle && (
+              <input
+                type="checkbox"
+                aria-label={`Seleccionar ${album.name}`}
+                checked={selectedIds.has(album.spotifyId)}
+                onChange={() => onToggle(album.spotifyId)}
+                className="h-4 w-4 rounded border-gray-300 text-blue-600"
+                onClick={(e) => e.stopPropagation()}
+              />
+            )}
+            <span className="flex-1 text-sm font-medium text-gray-900">{album.name}</span>
+            <ListItemTrailing>
+              <span className="text-xs text-gray-500">{album.artist}</span>
+            </ListItemTrailing>
+          </ListItem>
+        ))}
+      </List>
+    </div>
+  );
+}

--- a/frontend/src/pages/Library/Playlists.test.tsx
+++ b/frontend/src/pages/Library/Playlists.test.tsx
@@ -1,13 +1,13 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/test/msw/server';
 import { samplePlaylists } from '@/test/msw/fixtures';
 import { makeQueryWrapper } from '@/test/queryWrapper';
 import { Playlists } from './Playlists';
 
-function renderComponent() {
-  return render(<Playlists />, { wrapper: makeQueryWrapper() });
+function renderComponent(props: Partial<React.ComponentProps<typeof Playlists>> = {}) {
+  return render(<Playlists {...props} />, { wrapper: makeQueryWrapper() });
 }
 
 describe('Playlists', () => {
@@ -42,5 +42,39 @@ describe('Playlists', () => {
       expect(screen.getByText(playlist.name)).toBeInTheDocument();
       expect(screen.getByText(`${playlist.trackCount} canciones`)).toBeInTheDocument();
     }
+  });
+
+  describe('selection', () => {
+    it('renders select-all checkbox when onToggleAll is provided', async () => {
+      renderComponent({ onToggleAll: vi.fn(), onToggle: vi.fn(), selectionState: 'none' });
+      await waitFor(() => expect(screen.getByText(samplePlaylists[0].name)).toBeInTheDocument());
+      expect(screen.getByRole('checkbox', { name: /seleccionar todas las playlists/i })).toBeInTheDocument();
+    });
+
+    it('calls onToggleAll when select-all checkbox is clicked', async () => {
+      const onToggleAll = vi.fn();
+      renderComponent({ onToggleAll, onToggle: vi.fn(), selectionState: 'none' });
+      await waitFor(() => expect(screen.getByText(samplePlaylists[0].name)).toBeInTheDocument());
+      fireEvent.click(screen.getByRole('checkbox', { name: /seleccionar todas las playlists/i }));
+      expect(onToggleAll).toHaveBeenCalledOnce();
+    });
+
+    it('select-all checkbox is checked when selectionState is all', async () => {
+      const ids = new Set(samplePlaylists.map((p) => p.id));
+      renderComponent({ onToggleAll: vi.fn(), onToggle: vi.fn(), selectedIds: ids, selectionState: 'all' });
+      await waitFor(() => expect(screen.getByText(samplePlaylists[0].name)).toBeInTheDocument());
+      const checkbox = screen.getByRole('checkbox', { name: /seleccionar todas las playlists/i }) as HTMLInputElement;
+      expect(checkbox.checked).toBe(true);
+      expect(checkbox.indeterminate).toBe(false);
+    });
+
+    it('calls onToggle when a row checkbox is clicked', async () => {
+      const onToggle = vi.fn();
+      renderComponent({ onToggle, onToggleAll: vi.fn(), selectionState: 'none' });
+      await waitFor(() => expect(screen.getByText(samplePlaylists[0].name)).toBeInTheDocument());
+      const checkbox = screen.getByRole('checkbox', { name: new RegExp(`seleccionar ${samplePlaylists[0].name}`, 'i') });
+      fireEvent.click(checkbox);
+      expect(onToggle).toHaveBeenCalledWith(samplePlaylists[0].id);
+    });
   });
 });

--- a/frontend/src/pages/Library/Playlists.tsx
+++ b/frontend/src/pages/Library/Playlists.tsx
@@ -1,5 +1,6 @@
 import { Button, EmptyState, List, ListItem, ListItemTrailing, Skeleton } from '@/components/ui';
 import { usePlaylists } from '@/features/library/usePlaylists';
+import type { SelectionState } from '@/features/library/useSelection';
 
 function PlaylistSkeletons() {
   return (
@@ -11,7 +12,19 @@ function PlaylistSkeletons() {
   );
 }
 
-export function Playlists() {
+export interface PlaylistsProps {
+  selectedIds?: Set<string>;
+  onToggle?: (id: string) => void;
+  onToggleAll?: () => void;
+  selectionState?: SelectionState;
+}
+
+export function Playlists({
+  selectedIds = new Set(),
+  onToggle,
+  onToggleAll,
+  selectionState = 'none',
+}: PlaylistsProps) {
   const { data, isLoading, isError, refetch } = usePlaylists();
 
   if (isLoading) return <PlaylistSkeletons />;
@@ -35,15 +48,42 @@ export function Playlists() {
   }
 
   return (
-    <List>
-      {data.map((playlist) => (
-        <ListItem key={playlist.id} id={playlist.id}>
-          <span className="flex-1 text-sm font-medium text-gray-900">{playlist.name}</span>
-          <ListItemTrailing>
-            <span className="text-xs text-gray-500">{playlist.trackCount} canciones</span>
-          </ListItemTrailing>
-        </ListItem>
-      ))}
-    </List>
+    <div>
+      {onToggleAll && (
+        <div className="flex items-center gap-3 px-4 py-2 border-b border-gray-200 bg-gray-50">
+          <input
+            type="checkbox"
+            aria-label="Seleccionar todas las playlists"
+            checked={selectionState === 'all'}
+            ref={(el) => {
+              if (el) el.indeterminate = selectionState === 'some';
+            }}
+            onChange={onToggleAll}
+            className="h-4 w-4 rounded border-gray-300 text-blue-600"
+          />
+          <span className="text-xs text-gray-500">Seleccionar todas</span>
+        </div>
+      )}
+      <List selectedIds={[...selectedIds]} onSelect={onToggle}>
+        {data.map((playlist) => (
+          <ListItem key={playlist.id} id={playlist.id}>
+            {onToggle && (
+              <input
+                type="checkbox"
+                aria-label={`Seleccionar ${playlist.name}`}
+                checked={selectedIds.has(playlist.id)}
+                onChange={() => onToggle(playlist.id)}
+                className="h-4 w-4 rounded border-gray-300 text-blue-600"
+                onClick={(e) => e.stopPropagation()}
+              />
+            )}
+            <span className="flex-1 text-sm font-medium text-gray-900">{playlist.name}</span>
+            <ListItemTrailing>
+              <span className="text-xs text-gray-500">{playlist.trackCount} canciones</span>
+            </ListItemTrailing>
+          </ListItem>
+        ))}
+      </List>
+    </div>
   );
 }

--- a/frontend/src/pages/Library/index.tsx
+++ b/frontend/src/pages/Library/index.tsx
@@ -1,7 +1,14 @@
 import { useState } from 'react';
 import { Tabs, TabPanel } from '@/components/Library';
+import { SelectionSummary } from '@/components/Library/SelectionSummary';
 import type { TabDef } from '@/components/Library';
+import { useAppSection } from '@/hooks/useAppSection';
+import { useSelection } from '@/features/library';
+import { useMigrationSelection } from '@/features/migrate';
+import { usePlaylists } from '@/features/library/usePlaylists';
+import { useAlbums } from '@/features/library/useAlbums';
 import { Playlists } from './Playlists';
+import { Albums } from './Albums';
 
 const TABS: TabDef[] = [
   { id: 'playlists', label: 'Playlists' },
@@ -10,20 +17,44 @@ const TABS: TabDef[] = [
 
 export function LibraryPage() {
   const [activeTab, setActiveTab] = useState('playlists');
+  const { setSection } = useAppSection();
+
+  const { data: playlists = [] } = usePlaylists();
+  const { data: albums = [] } = useAlbums();
+
+  const playlistSelection = useSelection(playlists, (p) => p.id);
+  const albumSelection = useSelection(albums, (a) => a.spotifyId);
+
+  const migration = useMigrationSelection(playlistSelection.selectedIds, albumSelection.selectedIds);
 
   return (
-    <section aria-labelledby="library-heading" className="p-4">
+    <section aria-labelledby="library-heading" className="p-4 pb-20">
       <h2 id="library-heading" className="mb-4 text-xl font-semibold text-gray-900">
         Biblioteca
       </h2>
       <Tabs tabs={TABS} activeTab={activeTab} onTabChange={setActiveTab}>
         <TabPanel id="panel-playlists" labelledBy="tab-playlists" active={activeTab === 'playlists'}>
-          <Playlists />
+          <Playlists
+            selectedIds={playlistSelection.selectedIds}
+            onToggle={playlistSelection.toggle}
+            onToggleAll={playlistSelection.toggleAll}
+            selectionState={playlistSelection.selectionState}
+          />
         </TabPanel>
         <TabPanel id="panel-albums" labelledBy="tab-albums" active={activeTab === 'albums'}>
-          <div />
+          <Albums
+            selectedIds={albumSelection.selectedIds}
+            onToggle={albumSelection.toggle}
+            onToggleAll={albumSelection.toggleAll}
+            selectionState={albumSelection.selectionState}
+          />
         </TabPanel>
       </Tabs>
+      <SelectionSummary
+        playlistCount={migration.playlistCount}
+        albumCount={migration.albumCount}
+        onMigrate={() => setSection('migrate')}
+      />
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- Añade `useAlbums()` hook con TanStack Query y `Albums.tsx` con los 4 estados (loading/error/empty/success), espejo de la implementación de Playlists
- Añade `useSelection<T>(items, getId)`, hook genérico que mantiene un `Set` de ids y expone el estado tri-estado `none`/`some`/`all`
- Aplica `useSelection` a `Playlists.tsx` y `Albums.tsx`: checkbox por fila + checkbox select-all con estado indeterminate cuando la selección es parcial
- Añade `useMigrationSelection` que deriva conteos de playlists y álbumes seleccionados
- Añade `SelectionSummary`: barra sticky en el bottom de la sección Library con el conteo y botón "Migrar" (disabled si no hay selección); al hacer click navega a la sección "migrate" vía `useAppSection`
- `LibraryPage` eleva el estado de selección y conecta todos los componentes
- Conecta `App.tsx` con `AppSectionProvider` + `ToastProvider` y renderiza la página según la sección activa; añade navegación por secciones en el `Header`

## Closes

Closes #28, Closes #29, Closes #30, Closes #31

## Test plan

- [ ] `useSelection.test.ts`: selectAll → all, deselect uno → some, deselect resto → none
- [ ] `useAlbums.test.ts`: loading, success, empty, error
- [ ] `Albums.test.tsx`: 4 estados de carga + comportamiento de checkboxes
- [ ] `Playlists.test.tsx`: tests de selección añadidos (select-all, fila individual)
- [ ] `useMigrationSelection.test.ts`: conteos y isEmpty
- [ ] `SelectionSummary.test.tsx`: conteo correcto, disabled cuando vacío, enabled con selección, click llama onMigrate
- [ ] `pnpm exec vitest run` pasa 167/167 tests en verde
- [ ] `pnpm exec tsc --noEmit` sin errores
- [ ] `pnpm run build` exitoso
- [ ] Dev server muestra la app completa con nav funcional en http://localhost:5174