### PR TITLE
feat(ui): conectar App con secciones, nav en Header y ToastProvider

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -16,10 +16,8 @@ describe('App', () => {
     expect(screen.getByRole('heading', { name: /spotify.*yt music/i })).toBeInTheDocument()
   })
 
-  it('resolves the test useQuery and renders its data', async () => {
+  it('renders the connect section by default', () => {
     renderWithClient(<App />)
-    const status = await screen.findByTestId('ping-status')
-    await screen.findByText('ok')
-    expect(status).toHaveTextContent('ok')
+    expect(screen.getByText(/conectar spotify/i)).toBeInTheDocument()
   })
 })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,44 @@
-import { useQuery } from '@tanstack/react-query'
+import { AppShell } from '@/components/layout/AppShell'
+import { ToastProvider } from '@/components/ui'
+import { AppSectionProvider } from '@/hooks/useAppSection'
+import { useAppSection } from '@/hooks/useAppSection'
+import { LibraryPage } from '@/pages/Library'
+import { SpotifyConnect } from '@/pages/Connect/Spotify'
+import { YTMusicConnect } from '@/pages/Connect/YTMusic'
 
-function App() {
-  const { data } = useQuery({
-    queryKey: ['ping'],
-    queryFn: () => Promise.resolve({ ok: true }),
-  })
+function AppContent() {
+  const { section } = useAppSection()
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-4">
-      <h1 className="text-3xl font-bold">Spotify → YT Music</h1>
-      <p data-testid="ping-status">{data?.ok ? 'ok' : '...'}</p>
-    </main>
+    <AppShell>
+      {section === 'connect' && (
+        <div className="p-4 flex flex-col gap-6">
+          <SpotifyConnect />
+          <YTMusicConnect />
+        </div>
+      )}
+      {section === 'library' && <LibraryPage />}
+      {section === 'migrate' && (
+        <div className="flex items-center justify-center h-64 text-gray-400">
+          Migración (próximamente)
+        </div>
+      )}
+      {section === 'reports' && (
+        <div className="flex items-center justify-center h-64 text-gray-400">
+          Reportes (próximamente)
+        </div>
+      )}
+    </AppShell>
+  )
+}
+
+function App() {
+  return (
+    <ToastProvider>
+      <AppSectionProvider>
+        <AppContent />
+      </AppSectionProvider>
+    </ToastProvider>
   )
 }
 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,12 +1,38 @@
 import { useHealth } from '@/features/auth/useHealth';
+import { useAppSection } from '@/hooks/useAppSection';
+import type { AppSection } from '@/hooks/useAppSection';
 import { ConnectionStatus } from './ConnectionStatus';
+
+const NAV_ITEMS: { id: AppSection; label: string }[] = [
+  { id: 'connect', label: 'Conectar' },
+  { id: 'library', label: 'Biblioteca' },
+  { id: 'migrate', label: 'Migrar' },
+  { id: 'reports', label: 'Reportes' },
+];
 
 export function Header() {
   const { spotify, ytmusic } = useHealth();
+  const { section, setSection } = useAppSection();
 
   return (
-    <header className="flex h-14 items-center justify-between border-b bg-white px-4">
-      <h1 className="text-xl font-bold text-gray-900">Spotify → YT Music</h1>
+    <header className="flex h-14 items-center justify-between border-b bg-white px-4 gap-4">
+      <h1 className="text-xl font-bold text-gray-900 shrink-0">Spotify → YT Music</h1>
+      <nav className="flex gap-1">
+        {NAV_ITEMS.map((item) => (
+          <button
+            key={item.id}
+            onClick={() => setSection(item.id)}
+            className={[
+              'px-3 py-1.5 rounded-md text-sm font-medium transition-colors',
+              section === item.id
+                ? 'bg-gray-100 text-gray-900'
+                : 'text-gray-500 hover:text-gray-900 hover:bg-gray-50',
+            ].join(' ')}
+          >
+            {item.label}
+          </button>
+        ))}
+      </nav>
       <ConnectionStatus spotify={spotify} ytmusic={ytmusic} />
     </header>
   );


### PR DESCRIPTION
## Summary

- `App.tsx` monta `ToastProvider` + `AppSectionProvider` y renderiza la página correspondiente según la sección activa (`connect`, `library`, `migrate`, `reports`)
- `Header` añade navegación entre secciones con botones resaltando la activa
- `App.test.tsx` actualizado: el test de `ping-status` se reemplaza por verificación de la sección de conexión por defecto

## Test plan

- [ ] `pnpm exec vitest run` pasa 167/167 en verde
- [ ] Dev server muestra la app completa con nav funcional
- [ ] Clicar "Biblioteca" muestra la lista de playlists/albums con checkboxes
- [ ] Clicar "Migrar" desde la barra sticky navega a la sección de migración