### PR TITLE
feat(migrate): add playlist and album progress UI hooks and components

### DIFF
--- a/frontend/src/components/Migrate/AlbumProgress.tsx
+++ b/frontend/src/components/Migrate/AlbumProgress.tsx
@@ -1,0 +1,72 @@
+import { Card, CardBody } from '@/components/ui/Card';
+import type { AlbumProgressItem } from '@/features/migrate/useAlbumProgress';
+
+interface AlbumProgressProps {
+  albums: AlbumProgressItem[];
+  totalDiscovered: number;
+  savedCount: number;
+  foundCount: number;
+  notFoundCount: number;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  saved: 'Guardado',
+  'found (not saved)': 'Encontrado',
+  'not found': 'No encontrado',
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  saved: 'bg-green-100 text-green-700',
+  'found (not saved)': 'bg-yellow-100 text-yellow-700',
+  'not found': 'bg-red-100 text-red-700',
+};
+
+function AlbumItem({ album }: { album: AlbumProgressItem }) {
+  return (
+    <div className="flex items-center justify-between py-2">
+      <span className="truncate text-gray-900">{album.label}</span>
+      <span
+        className={[
+          'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+          STATUS_STYLES[album.status],
+        ].join(' ')}
+      >
+        {STATUS_LABELS[album.status]}
+      </span>
+    </div>
+  );
+}
+
+export function AlbumProgress({
+  albums,
+  totalDiscovered,
+  savedCount,
+  foundCount,
+  notFoundCount,
+}: AlbumProgressProps) {
+  if (totalDiscovered === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardBody className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-gray-900">
+            Álbumes ({albums.length} / {totalDiscovered})
+          </h3>
+        </div>
+        <div className="flex gap-4 text-sm">
+          <span className="text-green-700">{savedCount} guardados</span>
+          <span className="text-yellow-700">{foundCount} encontrados</span>
+          <span className="text-red-700">{notFoundCount} no encontrados</span>
+        </div>
+        <div className="divide-y divide-gray-100">
+          {albums.map((album, index) => (
+            <AlbumItem key={`${album.label}-${index}`} album={album} />
+          ))}
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/frontend/src/components/Migrate/PlaylistProgress.tsx
+++ b/frontend/src/components/Migrate/PlaylistProgress.tsx
@@ -1,0 +1,74 @@
+import { Card, CardBody } from '@/components/ui/Card';
+import type { PlaylistProgressItem } from '@/features/migrate/usePlaylistProgress';
+
+interface PlaylistProgressProps {
+  playlists: PlaylistProgressItem[];
+  totalDiscovered: number;
+}
+
+const STATUS_LABELS = {
+  pending: 'Pendiente',
+  in_progress: 'En progreso',
+  completed: 'Completada',
+};
+
+const STATUS_STYLES = {
+  pending: 'bg-gray-100 text-gray-600',
+  in_progress: 'bg-blue-100 text-blue-700',
+  completed: 'bg-green-100 text-green-700',
+};
+
+function PlaylistCard({ playlist }: { playlist: PlaylistProgressItem }) {
+  const progressPercent =
+    playlist.total > 0 ? (playlist.found / playlist.total) * 100 : 0;
+  const isInProgress = playlist.status === 'in_progress';
+
+  return (
+    <Card className={isInProgress ? 'border-blue-300 ring-2 ring-blue-100' : ''}>
+      <CardBody className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="font-medium text-gray-900 truncate">{playlist.name}</span>
+          <span
+            className={[
+              'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+              STATUS_STYLES[playlist.status],
+            ].join(' ')}
+          >
+            {STATUS_LABELS[playlist.status]}
+          </span>
+        </div>
+        <div className="h-2 w-full overflow-hidden rounded-full bg-gray-200">
+          <div
+            className="h-full bg-blue-600 transition-all duration-300"
+            style={{ width: `${progressPercent}%` }}
+          />
+        </div>
+        <div className="flex justify-between text-xs text-gray-500">
+          <span>
+            {playlist.found} / {playlist.total} encontradas
+          </span>
+          <span>{Math.round(progressPercent)}%</span>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+export function PlaylistProgress({ playlists, totalDiscovered }: PlaylistProgressProps) {
+  if (totalDiscovered === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-lg font-semibold text-gray-900">
+        Playlists ({playlists.length} / {totalDiscovered})
+      </h3>
+      <div className="space-y-2">
+        {playlists.map((playlist) => (
+          <PlaylistCard key={playlist.name} playlist={playlist} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/migrate/index.ts
+++ b/frontend/src/features/migrate/index.ts
@@ -2,3 +2,7 @@ export { useMigrationSelection } from './useMigrationSelection';
 export type { MigrationSelection } from './useMigrationSelection';
 export { useStartMigration } from './useStartMigration';
 export type { StartMigrationRequest, StartMigrationResponse } from './useStartMigration';
+export { usePlaylistProgress } from './usePlaylistProgress';
+export type { PlaylistProgressItem, PlaylistProgressStatus } from './usePlaylistProgress';
+export { useAlbumProgress } from './useAlbumProgress';
+export type { AlbumProgressItem } from './useAlbumProgress';

--- a/frontend/src/features/migrate/useAlbumProgress.test.ts
+++ b/frontend/src/features/migrate/useAlbumProgress.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { reduceAlbumEvents } from './useAlbumProgress';
+import type {
+  AlbumsDiscoveredEvent,
+  AlbumProcessedEvent,
+  MigrationEvent,
+} from '@/types/api';
+
+describe('reduceAlbumEvents', () => {
+  const makeEvent = (e: MigrationEvent): MigrationEvent => e;
+
+  it('returns empty when no events', () => {
+    const result = reduceAlbumEvents([]);
+    expect(result.albums).toEqual([]);
+    expect(result.totalDiscovered).toBe(0);
+    expect(result.savedCount).toBe(0);
+    expect(result.foundCount).toBe(0);
+    expect(result.notFoundCount).toBe(0);
+  });
+
+  it('tracks discovered albums count', () => {
+    const events: MigrationEvent[] = [
+      makeEvent({ type: 'AlbumsDiscovered', count: 5 }) as AlbumsDiscoveredEvent,
+    ];
+    const result = reduceAlbumEvents(events);
+    expect(result.totalDiscovered).toBe(5);
+  });
+
+  it('tracks saved album', () => {
+    const events: MigrationEvent[] = [
+      makeEvent({ type: 'AlbumsDiscovered', count: 1 }) as AlbumsDiscoveredEvent,
+      makeEvent({
+        type: 'AlbumProcessed',
+        label: 'Album 1',
+        status: 'saved',
+      }) as AlbumProcessedEvent,
+    ];
+    const result = reduceAlbumEvents(events);
+    expect(result.albums).toHaveLength(1);
+    expect(result.albums[0].label).toBe('Album 1');
+    expect(result.albums[0].status).toBe('saved');
+    expect(result.savedCount).toBe(1);
+    expect(result.foundCount).toBe(0);
+    expect(result.notFoundCount).toBe(0);
+  });
+
+  it('tracks found (not saved) album', () => {
+    const events: MigrationEvent[] = [
+      makeEvent({ type: 'AlbumsDiscovered', count: 1 }) as AlbumsDiscoveredEvent,
+      makeEvent({
+        type: 'AlbumProcessed',
+        label: 'Album 1',
+        status: 'found (not saved)',
+      }) as AlbumProcessedEvent,
+    ];
+    const result = reduceAlbumEvents(events);
+    expect(result.albums[0].status).toBe('found (not saved)');
+    expect(result.foundCount).toBe(1);
+  });
+
+  it('tracks not found album', () => {
+    const events: MigrationEvent[] = [
+      makeEvent({ type: 'AlbumsDiscovered', count: 1 }) as AlbumsDiscoveredEvent,
+      makeEvent({
+        type: 'AlbumProcessed',
+        label: 'Album 1',
+        status: 'not found',
+      }) as AlbumProcessedEvent,
+    ];
+    const result = reduceAlbumEvents(events);
+    expect(result.albums[0].status).toBe('not found');
+    expect(result.notFoundCount).toBe(1);
+  });
+
+  it('tracks multiple albums with correct counts', () => {
+    const events: MigrationEvent[] = [
+      makeEvent({ type: 'AlbumsDiscovered', count: 3 }) as AlbumsDiscoveredEvent,
+      makeEvent({
+        type: 'AlbumProcessed',
+        label: 'Album A',
+        status: 'saved',
+      }) as AlbumProcessedEvent,
+      makeEvent({
+        type: 'AlbumProcessed',
+        label: 'Album B',
+        status: 'found (not saved)',
+      }) as AlbumProcessedEvent,
+      makeEvent({
+        type: 'AlbumProcessed',
+        label: 'Album C',
+        status: 'not found',
+      }) as AlbumProcessedEvent,
+    ];
+    const result = reduceAlbumEvents(events);
+    expect(result.albums).toHaveLength(3);
+    expect(result.savedCount).toBe(1);
+    expect(result.foundCount).toBe(1);
+    expect(result.notFoundCount).toBe(1);
+  });
+
+  it('resets counts when new AlbumsDiscovered event arrives', () => {
+    const events: MigrationEvent[] = [
+      makeEvent({ type: 'AlbumsDiscovered', count: 2 }) as AlbumsDiscoveredEvent,
+      makeEvent({
+        type: 'AlbumProcessed',
+        label: 'Album A',
+        status: 'saved',
+      }) as AlbumProcessedEvent,
+      makeEvent({ type: 'AlbumsDiscovered', count: 1 }) as AlbumsDiscoveredEvent,
+      makeEvent({
+        type: 'AlbumProcessed',
+        label: 'Album X',
+        status: 'not found',
+      }) as AlbumProcessedEvent,
+    ];
+    const result = reduceAlbumEvents(events);
+    expect(result.totalDiscovered).toBe(1);
+    expect(result.albums).toHaveLength(1);
+    expect(result.savedCount).toBe(0);
+    expect(result.notFoundCount).toBe(1);
+  });
+});

--- a/frontend/src/features/migrate/useAlbumProgress.ts
+++ b/frontend/src/features/migrate/useAlbumProgress.ts
@@ -1,0 +1,54 @@
+import { useMemo } from 'react';
+import type { MigrationEvent, AlbumStatus } from '@/types/api';
+
+export interface AlbumProgressItem {
+  label: string;
+  status: AlbumStatus;
+}
+
+export interface UseAlbumProgressResult {
+  albums: AlbumProgressItem[];
+  totalDiscovered: number;
+  savedCount: number;
+  foundCount: number;
+  notFoundCount: number;
+}
+
+export function reduceAlbumEvents(events: MigrationEvent[]): UseAlbumProgressResult {
+  const albums: AlbumProgressItem[] = [];
+  let totalDiscovered = 0;
+  let savedCount = 0;
+  let foundCount = 0;
+  let notFoundCount = 0;
+
+  for (const event of events) {
+    if (event.type === 'AlbumsDiscovered') {
+      totalDiscovered = event.count;
+      albums.length = 0;
+      savedCount = 0;
+      foundCount = 0;
+      notFoundCount = 0;
+    } else if (event.type === 'AlbumProcessed') {
+      const item: AlbumProgressItem = {
+        label: event.label,
+        status: event.status,
+      };
+      albums.push(item);
+
+      if (event.status === 'saved') {
+        savedCount++;
+      } else if (event.status === 'found (not saved)') {
+        foundCount++;
+      } else if (event.status === 'not found') {
+        notFoundCount++;
+      }
+    }
+  }
+
+  return { albums, totalDiscovered, savedCount, foundCount, notFoundCount };
+}
+
+export function useAlbumProgress(events: MigrationEvent[]): UseAlbumProgressResult {
+  const result = useMemo(() => reduceAlbumEvents(events), [events]);
+  return result;
+}

--- a/frontend/src/features/migrate/usePlaylistProgress.test.ts
+++ b/frontend/src/features/migrate/usePlaylistProgress.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { reducePlaylistEvents } from './usePlaylistProgress';
+import type {
+  PlaylistsDiscoveredEvent,
+  PlaylistStartedEvent,
+  PlaylistFinishedEvent,
+  MigrationEvent,
+} from '@/types/api';
+
+describe('reducePlaylistEvents', () => {
+  const makeEvent = (e: MigrationEvent): MigrationEvent => e;
+
+  it('returns empty when no events', () => {
+    const result = reducePlaylistEvents([]);
+    expect(result.playlists).toEqual([]);
+    expect(result.totalDiscovered).toBe(0);
+  });
+
+  it('tracks discovered playlists count', () => {
+    const events: MigrationEvent[] = [
+      makeEvent({ type: 'PlaylistsDiscovered', count: 3 }) as PlaylistsDiscoveredEvent,
+    ];
+    const result = reducePlaylistEvents(events);
+    expect(result.totalDiscovered).toBe(3);
+  });
+
+  it('tracks in-progress playlist', () => {
+    const events: MigrationEvent[] = [
+      makeEvent({ type: 'PlaylistsDiscovered', count: 1 }) as PlaylistsDiscoveredEvent,
+      makeEvent({
+        type: 'PlaylistStarted',
+        name: 'My Playlist',
+        trackCount: 10,
+      }) as PlaylistStartedEvent,
+    ];
+    const result = reducePlaylistEvents(events);
+    expect(result.playlists).toHaveLength(1);
+    expect(result.playlists[0].name).toBe('My Playlist');
+    expect(result.playlists[0].status).toBe('in_progress');
+    expect(result.playlists[0].total).toBe(10);
+    expect(result.playlists[0].found).toBe(0);
+  });
+
+  it('tracks completed playlist with found/total', () => {
+    const events: MigrationEvent[] = [
+      makeEvent({ type: 'PlaylistsDiscovered', count: 1 }) as PlaylistsDiscoveredEvent,
+      makeEvent({
+        type: 'PlaylistStarted',
+        name: 'My Playlist',
+        trackCount: 10,
+      }) as PlaylistStartedEvent,
+      makeEvent({
+        type: 'PlaylistFinished',
+        name: 'My Playlist',
+        found: 8,
+        total: 10,
+        notFoundLabels: ['Track A', 'Track B'],
+      }) as PlaylistFinishedEvent,
+    ];
+    const result = reducePlaylistEvents(events);
+    expect(result.playlists).toHaveLength(1);
+    expect(result.playlists[0].status).toBe('completed');
+    expect(result.playlists[0].found).toBe(8);
+    expect(result.playlists[0].total).toBe(10);
+  });
+
+  it('tracks multiple playlists independently', () => {
+    const events: MigrationEvent[] = [
+      makeEvent({ type: 'PlaylistsDiscovered', count: 2 }) as PlaylistsDiscoveredEvent,
+      makeEvent({
+        type: 'PlaylistStarted',
+        name: 'Playlist A',
+        trackCount: 5,
+      }) as PlaylistStartedEvent,
+      makeEvent({
+        type: 'PlaylistStarted',
+        name: 'Playlist B',
+        trackCount: 3,
+      }) as PlaylistStartedEvent,
+      makeEvent({
+        type: 'PlaylistFinished',
+        name: 'Playlist A',
+        found: 5,
+        total: 5,
+        notFoundLabels: [],
+      }) as PlaylistFinishedEvent,
+    ];
+    const result = reducePlaylistEvents(events);
+    expect(result.playlists).toHaveLength(2);
+    const playlistA = result.playlists.find((p) => p.name === 'Playlist A');
+    const playlistB = result.playlists.find((p) => p.name === 'Playlist B');
+    expect(playlistA?.status).toBe('completed');
+    expect(playlistB?.status).toBe('in_progress');
+  });
+
+  it('updates playlist when started again after finished', () => {
+    const events: MigrationEvent[] = [
+      makeEvent({ type: 'PlaylistsDiscovered', count: 1 }) as PlaylistsDiscoveredEvent,
+      makeEvent({
+        type: 'PlaylistStarted',
+        name: 'Playlist A',
+        trackCount: 5,
+      }) as PlaylistStartedEvent,
+      makeEvent({
+        type: 'PlaylistFinished',
+        name: 'Playlist A',
+        found: 3,
+        total: 5,
+        notFoundLabels: [],
+      }) as PlaylistFinishedEvent,
+      makeEvent({
+        type: 'PlaylistStarted',
+        name: 'Playlist A',
+        trackCount: 10,
+      }) as PlaylistStartedEvent,
+    ];
+    const result = reducePlaylistEvents(events);
+    expect(result.playlists).toHaveLength(1);
+    expect(result.playlists[0].status).toBe('in_progress');
+    expect(result.playlists[0].total).toBe(10);
+  });
+});

--- a/frontend/src/features/migrate/usePlaylistProgress.ts
+++ b/frontend/src/features/migrate/usePlaylistProgress.ts
@@ -1,0 +1,60 @@
+import { useMemo } from 'react';
+import type { MigrationEvent } from '@/types/api';
+
+export type PlaylistProgressStatus = 'pending' | 'in_progress' | 'completed';
+
+export interface PlaylistProgressItem {
+  name: string;
+  status: PlaylistProgressStatus;
+  found: number;
+  total: number;
+}
+
+export interface UsePlaylistProgressResult {
+  playlists: PlaylistProgressItem[];
+  totalDiscovered: number;
+}
+
+export function reducePlaylistEvents(
+  events: MigrationEvent[],
+): UsePlaylistProgressResult {
+  const playlists: PlaylistProgressItem[] = [];
+  let totalDiscovered = 0;
+
+  for (const event of events) {
+    if (event.type === 'PlaylistsDiscovered') {
+      totalDiscovered = event.count;
+      playlists.length = 0;
+    } else if (event.type === 'PlaylistStarted') {
+      const index = playlists.findIndex((p) => p.name === event.name);
+      if (index === -1) {
+        playlists.push({
+          name: event.name,
+          status: 'in_progress',
+          found: 0,
+          total: event.trackCount,
+        });
+      } else {
+        playlists[index].status = 'in_progress';
+        playlists[index].total = event.trackCount;
+      }
+    } else if (event.type === 'PlaylistFinished') {
+      const index = playlists.findIndex((p) => p.name === event.name);
+      if (index !== -1) {
+        playlists[index] = {
+          name: event.name,
+          status: 'completed',
+          found: event.found,
+          total: event.total,
+        };
+      }
+    }
+  }
+
+  return { playlists, totalDiscovered };
+}
+
+export function usePlaylistProgress(events: MigrationEvent[]): UsePlaylistProgressResult {
+  const result = useMemo(() => reducePlaylistEvents(events), [events]);
+  return result;
+}


### PR DESCRIPTION
## Summary

- Added `usePlaylistProgress` hook with reducer that aggregates PlaylistsDiscovered, PlaylistStarted, and PlaylistFinished events into a progress structure
- Added `PlaylistProgress` component displaying cards with progress bars and status badges (pending/in_progress/completed)
- Added `useAlbumProgress` hook that aggregates AlbumsDiscovered and AlbumProcessed events with status counts
- Added `AlbumProgress` component displaying albums with status badges (saved/found/not found)
- Both hooks include comprehensive unit tests for intermediate and final states

## Closes

Closes #34, Closes #35

## Test plan

- [x] All 187 frontend tests pass
- [x] Lint passes (pre-existing warning in mockServiceWorker.js)
- [x] TypeScript type-check passes
- [x] Build passes