### PR TITLE
feat(reports): panel de detalle, export JSON, a11y y responsive

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { AppShell } from '@/components/layout/AppShell'
 import { ToastProvider } from '@/components/ui'
 import { AppSectionProvider } from '@/hooks/useAppSection'
@@ -7,23 +8,50 @@ import { SpotifyConnect } from '@/pages/Connect/Spotify'
 import { YTMusicConnect } from '@/pages/Connect/YTMusic'
 import { MigratePage } from '@/pages/Migrate'
 import { ReportsList } from '@/pages/Reports/List'
+import { ReportDetail } from '@/pages/Reports/Detail'
+import { downloadJson } from '@/lib/download'
+import type { MigrationReport } from '@/types/api'
 
 function AppContent() {
   const { section } = useAppSection()
+  const [selectedReport, setSelectedReport] = useState<MigrationReport | null>(null)
+
+  useEffect(() => {
+    const main = document.getElementById('main-content');
+    const heading = main?.querySelector('h2, h3');
+    if (heading instanceof HTMLElement) {
+      heading.setAttribute('tabindex', '-1');
+      heading.focus();
+    }
+  }, [section, selectedReport]);
 
   return (
     <AppShell>
       {section === 'connect' && (
-        <div className="p-4 flex flex-col gap-6">
+        <div className="p-4 sm:p-6 flex flex-col gap-6">
           <SpotifyConnect />
           <YTMusicConnect />
         </div>
       )}
       {section === 'library' && <LibraryPage />}
       {section === 'migrate' && <MigratePage />}
-      {section === 'reports' && (
-        <div className="p-4">
-          <ReportsList />
+      {section === 'reports' && selectedReport && (
+        <div className="p-4 sm:p-6">
+          <ReportDetail
+            report={selectedReport}
+            onClose={() => setSelectedReport(null)}
+            onDownload={(report) => {
+              const filename = report.id
+                ? `report-${report.id.slice(0, 8)}`
+                : 'report';
+              downloadJson(filename, report);
+            }}
+          />
+        </div>
+      )}
+      {section === 'reports' && !selectedReport && (
+        <div className="p-4 sm:p-6">
+          <ReportsList onSelectReport={setSelectedReport} />
         </div>
       )}
     </AppShell>

--- a/frontend/src/components/Library/SelectionSummary.tsx
+++ b/frontend/src/components/Library/SelectionSummary.tsx
@@ -15,7 +15,7 @@ export function SelectionSummary({ playlistCount, albumCount, onMigrate }: Selec
   const label = isEmpty ? 'Ningún elemento seleccionado' : `${parts.join(', ')} seleccionado${parts.length > 1 || playlistCount + albumCount > 1 ? 's' : ''}`;
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-10 flex items-center justify-between border-t border-gray-200 bg-white px-4 py-3 shadow-md">
+    <div className="fixed bottom-0 left-0 right-0 z-10 flex items-center justify-between border-t border-gray-200 bg-white px-4 py-3 shadow-md pb-[max(0.75rem,env(safe-area-inset-bottom))]">
       <span className="text-sm text-gray-600">{label}</span>
       <Button onClick={onMigrate} disabled={isEmpty}>
         Migrar

--- a/frontend/src/components/Library/Tabs.tsx
+++ b/frontend/src/components/Library/Tabs.tsx
@@ -46,7 +46,7 @@ export function Tabs({ tabs, activeTab, onTabChange, children }: TabsProps) {
 
   return (
     <div>
-      <div role="tablist" onKeyDown={handleKeyDown} className="flex border-b">
+      <div role="tablist" onKeyDown={handleKeyDown} className="flex border-b overflow-x-auto">
         {tabs.map((tab) => {
           const isActive = tab.id === activeTab;
           return (

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -9,8 +9,14 @@ interface AppShellProps {
 export function AppShell({ children }: AppShellProps) {
   return (
     <div className="flex min-h-screen flex-col">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:bg-blue-600 focus:text-white focus:rounded-md focus:font-medium"
+      >
+        Ir al contenido principal
+      </a>
       <Header />
-      <main className="flex-1">{children}</main>
+      <main id="main-content" role="main" className="flex-1">{children}</main>
       <Footer />
     </div>
   )

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -15,15 +15,16 @@ export function Header() {
   const { section, setSection } = useAppSection();
 
   return (
-    <header className="flex h-14 items-center justify-between border-b bg-white px-4 gap-4">
-      <h1 className="text-xl font-bold text-gray-900 shrink-0">Spotify → YT Music</h1>
-      <nav className="flex gap-1">
+    <header className="flex h-14 items-center justify-between border-b bg-white px-4 gap-2 sm:gap-4">
+      <h1 className="text-lg sm:text-xl font-bold text-gray-900 shrink-0">Spotify → YT Music</h1>
+      <nav aria-label="Navegación principal" className="flex gap-1 overflow-x-auto scrollbar-none whitespace-nowrap">
         {NAV_ITEMS.map((item) => (
           <button
             key={item.id}
             onClick={() => setSection(item.id)}
+            aria-current={section === item.id ? 'page' : undefined}
             className={[
-              'px-3 py-1.5 rounded-md text-sm font-medium transition-colors',
+              'px-3 py-1.5 rounded-md text-sm font-medium transition-colors shrink-0',
               section === item.id
                 ? 'bg-gray-100 text-gray-900'
                 : 'text-gray-500 hover:text-gray-900 hover:bg-gray-50',

--- a/frontend/src/features/reports/useReport.test.ts
+++ b/frontend/src/features/reports/useReport.test.ts
@@ -1,0 +1,64 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { makeQueryWrapper } from '@/test/queryWrapper';
+import { useReport } from './useReport';
+import { server } from '@/test/msw/server';
+import { http, HttpResponse } from 'msw';
+
+describe('useReport', () => {
+  it('fetches report successfully', async () => {
+    const { result } = renderHook(() => useReport('rep_1'), {
+      wrapper: makeQueryWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.id).toBe('rep_1');
+    expect(result.current.data?.playlists).toHaveLength(1);
+    expect(result.current.data?.albums).toHaveLength(1);
+    expect(result.current.data?.notFound).toHaveLength(2);
+  });
+
+  it('handles fetch error', async () => {
+    server.use(
+      http.get('*/api/reports/:id', () =>
+        HttpResponse.json({ message: 'Not found' }, { status: 404 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useReport('nonexistent'), {
+      wrapper: makeQueryWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeDefined();
+  });
+
+  it('does not fetch when id is empty', () => {
+    const { result } = renderHook(() => useReport(''), {
+      wrapper: makeQueryWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('returns report with correct id from params', async () => {
+    const { result } = renderHook(() => useReport('custom-id'), {
+      wrapper: makeQueryWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.id).toBe('custom-id');
+  });
+});

--- a/frontend/src/features/reports/useReport.ts
+++ b/frontend/src/features/reports/useReport.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { http } from '@/lib/http';
+import type { MigrationReport } from '@/types/api';
+
+export function useReport(id: string) {
+  return useQuery({
+    queryKey: ['reports', id],
+    queryFn: () => http.get<MigrationReport>(`/reports/${id}`),
+    enabled: !!id,
+  });
+}

--- a/frontend/src/hooks/useFocusTrap.test.tsx
+++ b/frontend/src/hooks/useFocusTrap.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+import { useRef } from 'react';
+import { describe, expect, it } from 'vitest';
+import { useFocusTrap } from './useFocusTrap';
+
+function TrapTestComponent({ active }: { active: boolean }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(ref, active);
+
+  return (
+    <div ref={ref} data-testid="trap">
+      <button type="button">First</button>
+      <input type="text" aria-label="Middle" />
+      <button type="button">Last</button>
+    </div>
+  );
+}
+
+describe('useFocusTrap', () => {
+  it('focuses first focusable element when activated', () => {
+    render(<TrapTestComponent active />);
+
+    expect(document.activeElement).toHaveTextContent('First');
+  });
+
+  it('does not focus elements when inactive', () => {
+    const previousActive = document.activeElement;
+    render(<TrapTestComponent active={false} />);
+
+    expect(document.activeElement).toBe(previousActive);
+  });
+
+  it('wraps focus forward with Tab', () => {
+    render(<TrapTestComponent active />);
+
+    const lastButton = screen.getByText('Last');
+    lastButton.focus();
+
+    const event = new KeyboardEvent('keydown', { key: 'Tab' });
+    screen.getByTestId('trap').dispatchEvent(event);
+
+    expect(document.activeElement).toHaveTextContent('First');
+  });
+
+  it('wraps focus backward with Shift+Tab', () => {
+    render(<TrapTestComponent active />);
+
+    const firstButton = screen.getByText('First');
+    firstButton.focus();
+
+    const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true });
+    screen.getByTestId('trap').dispatchEvent(event);
+
+    expect(document.activeElement).toHaveTextContent('Last');
+  });
+
+  it('restores focus to previous element on cleanup', () => {
+    const container = document.createElement('div');
+    container.tabIndex = -1;
+    document.body.appendChild(container);
+    container.focus();
+
+    const { unmount } = render(<TrapTestComponent active />);
+
+    unmount();
+
+    expect(document.activeElement).toBe(container);
+    document.body.removeChild(container);
+  });
+});

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+export function useFocusTrap(containerRef: RefObject<HTMLElement | null>, active: boolean) {
+  const previousFocus = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!active || !containerRef.current) return;
+
+    const container = containerRef.current;
+    const focusable = container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+    if (focusable.length === 0) return;
+
+    previousFocus.current = document.activeElement as HTMLElement;
+    focusable[0].focus();
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'Tab') return;
+
+      const elements = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS));
+      if (elements.length === 0) return;
+
+      const first = elements[0];
+      const last = elements[elements.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    container.addEventListener('keydown', handleKeyDown);
+    return () => {
+      container.removeEventListener('keydown', handleKeyDown);
+      previousFocus.current?.focus();
+    };
+  }, [containerRef, active]);
+}

--- a/frontend/src/lib/download.test.ts
+++ b/frontend/src/lib/download.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { downloadJson } from './download';
+
+describe('downloadJson', () => {
+  let createElementSpy: ReturnType<typeof vi.spyOn>;
+  let createObjectURLSpy: ReturnType<typeof vi.spyOn>;
+  let revokeObjectURLSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    createElementSpy = vi.spyOn(document, 'createElement');
+    createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url');
+    revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates a blob URL and triggers download', () => {
+    const data = { foo: 'bar' };
+
+    downloadJson('test-report', data);
+
+    expect(createObjectURLSpy).toHaveBeenCalledWith(
+      expect.any(Blob),
+    );
+
+    const blob = createObjectURLSpy.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe('application/json');
+
+    const link = createElementSpy.mock.results[0].value as HTMLAnchorElement;
+    expect(link.download).toBe('test-report.json');
+    expect(link.href).toBe('blob:mock-url');
+  });
+
+  it('appends .json extension if not present', () => {
+    downloadJson('my-report', { ok: true });
+
+    const link = createElementSpy.mock.results[0].value as HTMLAnchorElement;
+    expect(link.download).toBe('my-report.json');
+  });
+
+  it('does not double .json extension', () => {
+    downloadJson('my-report.json', { ok: true });
+
+    const link = createElementSpy.mock.results[0].value as HTMLAnchorElement;
+    expect(link.download).toBe('my-report.json');
+  });
+
+  it('revokes the object URL after download', () => {
+    downloadJson('test', { ok: true });
+
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:mock-url');
+  });
+
+  it('removes the link from the DOM after click', () => {
+    const appendChildSpy = vi.spyOn(document.body, 'appendChild');
+    const removeChildSpy = vi.spyOn(document.body, 'removeChild');
+
+    downloadJson('test', { ok: true });
+
+    const link = createElementSpy.mock.results[0].value as HTMLAnchorElement;
+    expect(appendChildSpy).toHaveBeenCalledWith(link);
+    expect(removeChildSpy).toHaveBeenCalledWith(link);
+  });
+});

--- a/frontend/src/lib/download.ts
+++ b/frontend/src/lib/download.ts
@@ -1,0 +1,13 @@
+export function downloadJson(filename: string, data: unknown): void {
+  const json = JSON.stringify(data, null, 2);
+  const blob = new Blob([json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename.endsWith('.json') ? filename : `${filename}.json`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/pages/Library/index.tsx
+++ b/frontend/src/pages/Library/index.tsx
@@ -28,7 +28,7 @@ export function LibraryPage() {
   const migration = useMigrationSelection(playlistSelection.selectedIds, albumSelection.selectedIds);
 
   return (
-    <section aria-labelledby="library-heading" className="p-4 pb-20">
+    <section aria-labelledby="library-heading" className="p-4 sm:p-6 pb-20">
       <h2 id="library-heading" className="mb-4 text-xl font-semibold text-gray-900">
         Biblioteca
       </h2>

--- a/frontend/src/pages/Migrate/EventLog.tsx
+++ b/frontend/src/pages/Migrate/EventLog.tsx
@@ -83,6 +83,8 @@ export function EventLog({ jobId }: EventLogProps) {
       <ConnectionBanner state={state} retryCount={retryCount} onRetry={retry} />
       <div
         ref={containerRef}
+        role="log"
+        aria-live="polite"
         className="h-64 overflow-y-auto bg-gray-50 border rounded-md p-3 font-mono text-sm"
       >
         {events.length === 0 && !isReconnecting ? (

--- a/frontend/src/pages/Migrate/index.tsx
+++ b/frontend/src/pages/Migrate/index.tsx
@@ -24,7 +24,7 @@ export function MigratePage() {
 
   if (migration.isEmpty && !jobId) {
     return (
-      <div className="p-4 flex flex-col items-center justify-center h-64 gap-4">
+      <div className="p-4 sm:p-6 flex flex-col items-center justify-center h-64 gap-4">
         <p className="text-gray-600">No hay elementos seleccionados.</p>
         <button
           onClick={() => setSection('library')}
@@ -38,7 +38,7 @@ export function MigratePage() {
 
   if (jobId) {
     return (
-      <section className="p-4">
+      <section className="p-4 sm:p-6">
         <h2 className="mb-4 text-xl font-semibold text-gray-900">Migración en Progreso</h2>
         <EventLog jobId={jobId} />
       </section>
@@ -46,7 +46,7 @@ export function MigratePage() {
   }
 
   return (
-    <section className="p-4 flex flex-col gap-4">
+    <section className="p-4 sm:p-6 flex flex-col gap-4">
       <h2 className="text-xl font-semibold text-gray-900">Confirmar Migración</h2>
       <div className="text-gray-700">
         <p>¿Confirmas que quieres migrar?</p>

--- a/frontend/src/pages/Reports/Detail.test.tsx
+++ b/frontend/src/pages/Reports/Detail.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { makeQueryWrapper } from '@/test/queryWrapper';
+import { ReportDetail } from './Detail';
+import { sampleReport } from '@/test/msw/fixtures';
+import { server } from '@/test/msw/server';
+import { http, HttpResponse } from 'msw';
+
+describe('ReportDetail', () => {
+  const renderDetail = (props: { onClose: () => void; onDownload?: () => void }) => {
+    return render(<ReportDetail report={sampleReport} {...props} />, {
+      wrapper: makeQueryWrapper(),
+    });
+  };
+
+  it('shows loading skeleton initially', () => {
+    renderDetail({ onClose: vi.fn() });
+    expect(screen.getAllByTestId('skeleton')).toHaveLength(9);
+  });
+
+  it('renders playlists section', async () => {
+    renderDetail({ onClose: vi.fn() });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Playlists/)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('40/42 encontradas')).toBeInTheDocument();
+  });
+
+  it('renders albums section', async () => {
+    renderDetail({ onClose: vi.fn() });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Álbumes/)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Radiohead - In Rainbows')).toBeInTheDocument();
+    expect(screen.getByText('saved')).toBeInTheDocument();
+  });
+
+  it('renders not found section', async () => {
+    renderDetail({ onClose: vi.fn() });
+
+    await waitFor(() => {
+      expect(screen.getByText(/No encontrados/)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Artista oscuro - Pista rara')).toBeInTheDocument();
+    expect(screen.getByText('Otro - Pista')).toBeInTheDocument();
+  });
+
+  it('calls onClose when clicking Cerrar', async () => {
+    const onClose = vi.fn();
+    renderDetail({ onClose });
+
+    await waitFor(() => {
+      expect(screen.getByText('Cerrar')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Cerrar'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('shows download button when onDownload is provided', async () => {
+    const onDownload = vi.fn();
+    renderDetail({ onClose: vi.fn(), onDownload });
+
+    await waitFor(() => {
+      expect(screen.getByText('Descargar JSON')).toBeInTheDocument();
+    });
+  });
+
+  it('does not show download button when onDownload is not provided', async () => {
+    renderDetail({ onClose: vi.fn() });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Descargar JSON')).not.toBeInTheDocument();
+    });
+  });
+
+  it('calls onDownload with report when clicking Descargar JSON', async () => {
+    const onDownload = vi.fn();
+    renderDetail({ onClose: vi.fn(), onDownload });
+
+    await waitFor(() => {
+      expect(screen.getByText('Descargar JSON')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Descargar JSON'));
+    expect(onDownload).toHaveBeenCalledWith(
+      expect.objectContaining({ id: sampleReport.id }),
+    );
+  });
+
+  it('shows error state on fetch failure', async () => {
+    server.use(
+      http.get('*/api/reports/:id', () =>
+        HttpResponse.json({ message: 'Error' }, { status: 500 }),
+      ),
+    );
+
+    renderDetail({ onClose: vi.fn() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Error al cargar el detalle')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty messages when sections are empty', async () => {
+    const emptyReport = { id: 'empty', playlists: [], albums: [], notFound: [] };
+    server.use(
+      http.get('*/api/reports/:id', () => HttpResponse.json(emptyReport)),
+    );
+
+    renderDetail({ onClose: vi.fn() });
+
+    await waitFor(() => {
+      expect(screen.getByText('No se migraron playlists.')).toBeInTheDocument();
+    });
+    expect(screen.getByText('No se migraron álbumes.')).toBeInTheDocument();
+    expect(screen.getByText('Todos los items fueron encontrados.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Reports/Detail.tsx
+++ b/frontend/src/pages/Reports/Detail.tsx
@@ -1,0 +1,157 @@
+import { useRef } from 'react';
+import { Card, CardBody, EmptyState, Skeleton } from '@/components/ui';
+import { useReport } from '@/features/reports/useReport';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
+import type { MigrationReport } from '@/types/api';
+
+interface ReportDetailProps {
+  report: MigrationReport;
+  onClose: () => void;
+  onDownload?: (report: MigrationReport) => void;
+}
+
+function SectionSkeleton() {
+  return (
+    <Card>
+      <CardBody>
+        <div className="flex flex-col gap-2">
+          <Skeleton variant="text" className="w-1/3" />
+          <Skeleton variant="text" className="w-2/3" />
+          <Skeleton variant="text" className="w-1/2" />
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+export function ReportDetail({ report, onClose, onDownload }: ReportDetailProps) {
+  const id = report.id ?? '';
+  const containerRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(containerRef, true);
+  const { data, isLoading, error } = useReport(id);
+  const resolved = data ?? report;
+
+  return (
+    <div ref={containerRef} className="flex flex-col gap-4" aria-busy={isLoading}>
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-900">
+          {resolved.id ? `Reporte ${resolved.id.slice(0, 8)}` : 'Detalle del reporte'}
+        </h2>
+        <div className="flex gap-2">
+          {onDownload && (
+            <button
+              type="button"
+              onClick={() => onDownload(resolved)}
+              className="px-3 py-1.5 text-sm font-medium text-gray-700 border border-gray-300 rounded-md hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              Descargar JSON
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-sm font-medium text-gray-700 border border-gray-300 rounded-md hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          >
+            Cerrar
+          </button>
+        </div>
+      </div>
+
+      {isLoading && (
+        <div className="flex flex-col gap-4">
+          <SectionSkeleton />
+          <SectionSkeleton />
+          <SectionSkeleton />
+        </div>
+      )}
+
+      {error && (
+        <EmptyState
+          title="Error al cargar el detalle"
+          description="No se pudo obtener la información completa del reporte."
+        />
+      )}
+
+      {!isLoading && !error && (
+        <div className="flex flex-col gap-4">
+          <section>
+            <h3 className="mb-2 text-sm font-semibold text-gray-700">
+              Playlists ({resolved.playlists.length})
+            </h3>
+            {resolved.playlists.length === 0 ? (
+              <p className="text-sm text-gray-500">No se migraron playlists.</p>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {resolved.playlists.map((pl, idx) => (
+                  <Card key={idx}>
+                    <CardBody>
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm font-medium text-gray-900">{pl.name}</span>
+                        <span className="text-sm text-gray-600">
+                          {pl.found}/{pl.total} encontradas
+                        </span>
+                      </div>
+                    </CardBody>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </section>
+
+          <section>
+            <h3 className="mb-2 text-sm font-semibold text-gray-700">
+              Álbumes ({resolved.albums.length})
+            </h3>
+            {resolved.albums.length === 0 ? (
+              <p className="text-sm text-gray-500">No se migraron álbumes.</p>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {resolved.albums.map((album, idx) => {
+                  const statusColors: Record<string, string> = {
+                    saved: 'text-green-700',
+                    'found (not saved)': 'text-yellow-700',
+                    'not found': 'text-red-700',
+                  };
+                  return (
+                    <Card key={idx}>
+                      <CardBody>
+                        <div className="flex items-center justify-between">
+                          <span className="text-sm font-medium text-gray-900">{album.label}</span>
+                          <span className={`text-sm font-medium ${statusColors[album.status]}`}>
+                            {album.status}
+                          </span>
+                        </div>
+                      </CardBody>
+                    </Card>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+
+          <section>
+            <h3 className="mb-2 text-sm font-semibold text-gray-700">
+              No encontrados ({resolved.notFound.length})
+            </h3>
+            {resolved.notFound.length === 0 ? (
+              <p className="text-sm text-gray-500">Todos los items fueron encontrados.</p>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {resolved.notFound.map((item, idx) => (
+                  <Card key={idx}>
+                    <CardBody>
+                      <div className="flex flex-col gap-0.5">
+                        <span className="text-sm font-medium text-gray-900">{item.item}</span>
+                        <span className="text-xs text-gray-500">{item.context}</span>
+                      </div>
+                    </CardBody>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Reports/List.tsx
+++ b/frontend/src/pages/Reports/List.tsx
@@ -38,7 +38,7 @@ function ReportItem({
                 )}
               </div>
             </div>
-            <span className="text-gray-400">→</span>
+            <span className="text-gray-500">→</span>
           </div>
         </CardBody>
       </Card>
@@ -67,7 +67,12 @@ export function ReportsList({ onSelectReport }: ReportsListProps) {
   const { data, isLoading, error } = useReports();
 
   if (isLoading) {
-    return <SkeletonList />;
+    return (
+      <div aria-busy="true" role="status">
+        <span className="sr-only">Cargando reportes...</span>
+        <SkeletonList />
+      </div>
+    );
   }
 
   if (error) {


### PR DESCRIPTION
## Summary

- Panel de detalle del report con tres secciones (Playlists, Albums, Not found) y boton Cerrar
- Export de report como JSON via boton Descargar JSON
- Skip-link a contenido principal, lang=es, role=main, aria-current=page en nav
- Focus management al cambiar de seccion y focus trap en el panel de detalle
- aria-live=polite en EventLog, aria-busy en estados de carga
- Fix de contraste (gray-400 a gray-500)
- Layout responsive en Header, Tabs, SelectionSummary y todas las paginas

## Closes

Closes #40, Closes #41, Closes #42, Closes #43, Closes #44

## Test plan

- [ ] Click en un report del listado abre el panel de detalle con las tres secciones
- [ ] Boton Cerrar vuelve al listado
- [ ] Boton Descargar JSON genera y descarga el archivo
- [ ] Skip-link visible al navegar con Tab y lleva al contenido principal
- [ ] Foco se mueve al heading al cambiar de seccion
- [ ] Foco queda atrapado dentro del panel de detalle (Tab/Shift+Tab ciclan)
- [ ] aria-live anuncia eventos de migracion en screen readers
- [ ] Contraste AA verificado en Header, botones primarios, badges de estado
- [ ] No hay scroll horizontal en breakpoint sm
- [ ] Header nav se vuelve scrollable en mobile
- [ ] SelectionSummary respeta safe area en iPhone
- [ ] 241 tests passing, lint green, tsc --noEmit green, build green