### PR TITLE
fix(ytmusic): typed exceptions, transient retry vs fatal propagation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,16 @@ in git history, so check the relevant commit before "improving" any of this.
   surfacing as `JSONDecodeError`. The fix is exponential backoff in
   [ytmusic_client.py `_add_chunk_with_retry`](backend/src/spotify_to_ytmusic/core/ytmusic_client.py).
   Don't catch and silently ignore — silent drops cost the user data.
+- **`YTMusicClient` distinguishes transient from fatal errors.** Public
+  methods can raise `YTMusicTransientError` (network/throttle, retries
+  already exhausted) or `YTMusicFatalError` (auth, 4xx, anything not
+  classified as transient). Never write `except Exception: return None`
+  in this module — use `_classify_exception` so fatals propagate
+  immediately instead of burning the retry budget. The `Migrator`
+  catches `YTMusicFatalError` per playlist/album and records the reason
+  in `MigrationReport.error` so the user sees why the item failed.
+  `YTMusicAuthError` is reserved for the construction-time check in
+  `_verify_auth`.
 - **403s from `playlist_tracks` are normal** for playlists the user doesn't
   fully own (e.g. some collaborative or algorithmic ones). `load_playlist_by_id`
   returns `None` in that case; the migrator just skips the playlist.

--- a/backend/src/spotify_to_ytmusic/core/migrator.py
+++ b/backend/src/spotify_to_ytmusic/core/migrator.py
@@ -22,7 +22,11 @@ from spotify_to_ytmusic.core.models import (
 )
 from spotify_to_ytmusic.core.spotify_client import SpotifyClient
 from spotify_to_ytmusic.core.track_cache import TrackCache
-from spotify_to_ytmusic.core.ytmusic_client import YTMusicClient
+from spotify_to_ytmusic.core.ytmusic_client import (
+    YTMusicClient,
+    YTMusicFatalError,
+    YTMusicTransientError,
+)
 
 
 def _noop(_event) -> None:
@@ -73,21 +77,33 @@ class Migrator:
                     MissingItem(context=f"playlist:{playlist.name}", item=track.label)
                 )
 
-        yt_playlist_id = self.ytmusic.create_playlist(
-            playlist.name, playlist.description, video_ids
-        )
+        yt_playlist_id: str | None = None
+        error_message: str | None = None
+        try:
+            yt_playlist_id = self.ytmusic.create_playlist(
+                playlist.name, playlist.description, video_ids
+            )
+        except YTMusicFatalError as exc:
+            # Per-playlist abort: record the error and move on so a single
+            # broken playlist does not kill the whole job.
+            error_message = str(exc)
+        except YTMusicTransientError as exc:
+            error_message = f"transient (max retries exceeded): {exc}"
+
+        finished_found = len(video_ids) if error_message is None else 0
         self.report.playlists.append(
             PlaylistMigrationResult(
                 name=playlist.name,
                 total=len(playlist.tracks),
-                found=len(video_ids),
+                found=finished_found,
                 yt_playlist_id=yt_playlist_id,
+                error=error_message,
             )
         )
         self.on_event(
             PlaylistFinished(
                 name=playlist.name,
-                found=len(video_ids),
+                found=finished_found,
                 total=len(playlist.tracks),
                 not_found_labels=not_found,
             )
@@ -99,6 +115,8 @@ class Migrator:
         if hit:
             return cached
         time.sleep(YTMUSIC_SEARCH_DELAY_S)
+        # YTMusicFatalError propagates: auth/quota expired mid-job aborts the
+        # whole job. Re-running picks up where the TrackCache left off.
         video_id = self.ytmusic.search_song(track.name, track.artist)
         if track.spotify_id:
             if video_id:
@@ -115,14 +133,39 @@ class Migrator:
 
     def _migrate_album(self, album: Album) -> None:
         time.sleep(YTMUSIC_SEARCH_DELAY_S)
-        match = self.ytmusic.search_album(album.name, album.artist)
+        try:
+            match = self.ytmusic.search_album(album.name, album.artist)
+        except YTMusicFatalError as exc:
+            self.report.albums.append(
+                AlbumMigrationResult(
+                    label=album.label,
+                    status="not found",
+                    error=str(exc),
+                )
+            )
+            self.on_event(AlbumProcessed(label=album.label, status="not found"))
+            return
 
         if not match or not match.get("browseId"):
             self.report.not_found.append(MissingItem(context="album", item=album.label))
             self.on_event(AlbumProcessed(label=album.label, status="not found"))
             return
 
-        saved = self.ytmusic.save_album(match["browseId"])
+        error_message: str | None = None
+        saved = False
+        try:
+            saved = self.ytmusic.save_album(match["browseId"])
+        except YTMusicFatalError as exc:
+            error_message = str(exc)
+        except YTMusicTransientError as exc:
+            error_message = f"transient (max retries exceeded): {exc}"
+
         status = "saved" if saved else "found (not saved)"
-        self.report.albums.append(AlbumMigrationResult(label=album.label, status=status))
+        self.report.albums.append(
+            AlbumMigrationResult(
+                label=album.label,
+                status=status,
+                error=error_message,
+            )
+        )
         self.on_event(AlbumProcessed(label=album.label, status=status))

--- a/backend/src/spotify_to_ytmusic/core/models.py
+++ b/backend/src/spotify_to_ytmusic/core/models.py
@@ -50,12 +50,14 @@ class PlaylistMigrationResult:
     total: int
     found: int
     yt_playlist_id: str | None
+    error: str | None = None
 
 
 @dataclass
 class AlbumMigrationResult:
     label: str
     status: str  # "saved" | "found (not saved)"
+    error: str | None = None
 
 
 @dataclass

--- a/backend/src/spotify_to_ytmusic/core/ytmusic_client.py
+++ b/backend/src/spotify_to_ytmusic/core/ytmusic_client.py
@@ -1,8 +1,11 @@
 """YouTube Music client wrapping ytmusicapi with retry/normalization logic."""
+import json
 import time
 from typing import Optional
 
+import requests
 from ytmusicapi import YTMusic
+from ytmusicapi.exceptions import YTMusicServerError, YTMusicUserError
 
 from spotify_to_ytmusic.core.config import (
     BROWSER_AUTH_FILE,
@@ -16,7 +19,44 @@ from spotify_to_ytmusic.core.text import normalize
 
 
 class YTMusicAuthError(RuntimeError):
-    pass
+    """Raised on construction when the browser session is invalid/expired."""
+
+
+class YTMusicTransientError(RuntimeError):
+    """Network blips, throttling, or partial JSON responses. Retried with backoff."""
+
+
+class YTMusicFatalError(RuntimeError):
+    """Auth/quota/4xx persistent failures. Propagate so the Migrator decides what to skip."""
+
+
+def _classify_exception(exc: BaseException) -> type:
+    """Map a caught exception to the kind we treat it as.
+
+    Anything we cannot positively identify as transient is fatal: silent
+    retries on unknown errors burn quota and hide real bugs.
+    """
+    if isinstance(exc, json.JSONDecodeError):
+        return YTMusicTransientError
+    if isinstance(
+        exc,
+        (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.ChunkedEncodingError,
+        ),
+    ):
+        return YTMusicTransientError
+    if isinstance(exc, requests.exceptions.HTTPError):
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status is not None and status >= 500:
+            return YTMusicTransientError
+        return YTMusicFatalError
+    if isinstance(exc, YTMusicServerError):
+        return YTMusicTransientError
+    if isinstance(exc, YTMusicUserError):
+        return YTMusicFatalError
+    return YTMusicFatalError
 
 
 class YTMusicClient:
@@ -79,7 +119,13 @@ class YTMusicClient:
         for query in queries:
             try:
                 results = self.yt.search(query, **search_kwargs)
-            except Exception:
+            except Exception as exc:
+                if _classify_exception(exc) is YTMusicFatalError:
+                    raise YTMusicFatalError(
+                        f"Search failed for query {query!r}: "
+                        f"{type(exc).__name__}: {exc}"
+                    ) from exc
+                # Transient: skip this query variant and try the next one.
                 continue
 
             preferred = self._find_artist_match(results, id_field, normalized_artist)
@@ -111,17 +157,27 @@ class YTMusicClient:
 
     def create_playlist(
         self, name: str, description: str, video_ids: list[str]
-    ) -> Optional[str]:
+    ) -> str:
         try:
             playlist_id = self.yt.create_playlist(name, description)
-        except Exception:
-            return None
+        except Exception as exc:
+            raise YTMusicFatalError(
+                f"Failed to create playlist {name!r}: "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+        if not playlist_id or not isinstance(playlist_id, str):
+            # Some ytmusicapi failure modes return a status dict instead of an
+            # id. Treat that as fatal: there is nothing to add tracks to.
+            raise YTMusicFatalError(
+                f"create_playlist returned invalid id for {name!r}: "
+                f"{playlist_id!r}"
+            )
         for chunk in self._chunked(video_ids, YTMUSIC_PLAYLIST_CHUNK_SIZE):
             self._add_chunk_with_retry(playlist_id, chunk)
             time.sleep(YTMUSIC_PLAYLIST_CHUNK_DELAY_S)
         return playlist_id
 
-    def _add_chunk_with_retry(self, playlist_id: str, chunk: list[str]) -> bool:
+    def _add_chunk_with_retry(self, playlist_id: str, chunk: list[str]) -> None:
         # YT Music throttles add_playlist_items intermittently and the response
         # comes back empty, surfacing as a JSONDecodeError. The failure is
         # transient: a backoff retry recovers the same chunk.
@@ -129,21 +185,33 @@ class YTMusicClient:
         # chunk on any duplicate videoId (Spotify allows repeats and YT search
         # can collapse distinct tracks to the same id).
         delay = YTMUSIC_ADD_ITEMS_BACKOFF_BASE_S
+        last_response: object = None
+        last_exc: Exception | None = None
         for attempt in range(1, YTMUSIC_ADD_ITEMS_MAX_RETRIES + 1):
             try:
                 response = self.yt.add_playlist_items(
                     playlist_id, chunk, duplicates=True
                 )
-            except Exception:
+            except Exception as exc:
+                if _classify_exception(exc) is YTMusicFatalError:
+                    raise YTMusicFatalError(
+                        f"Failed to add chunk to playlist {playlist_id}: "
+                        f"{type(exc).__name__}: {exc}"
+                    ) from exc
+                last_exc = exc
                 response = None
-            if isinstance(response, dict) and str(response.get("status", "")).startswith(
-                "STATUS_SUCCEEDED"
-            ):
-                return True
+            last_response = response
+            if isinstance(response, dict) and str(
+                response.get("status", "")
+            ).startswith("STATUS_SUCCEEDED"):
+                return
             if attempt < YTMUSIC_ADD_ITEMS_MAX_RETRIES:
                 time.sleep(delay)
                 delay *= 2
-        return False
+        raise YTMusicTransientError(
+            f"add_playlist_items exhausted retries for playlist {playlist_id} "
+            f"(last response: {last_response!r}, last exc: {last_exc!r})"
+        )
 
     @staticmethod
     def _chunked(items: list, size: int):
@@ -151,12 +219,26 @@ class YTMusicClient:
             yield items[i : i + size]
 
     def save_album(self, browse_id: str) -> bool:
-        try:
-            album = self.yt.get_album(browse_id)
-            audio_playlist_id = album.get("audioPlaylistId")
-            if not audio_playlist_id:
-                return False
-            self.yt.rate_playlist(audio_playlist_id, "LIKE")
-            return True
-        except Exception:
-            return False
+        delay = YTMUSIC_ADD_ITEMS_BACKOFF_BASE_S
+        last_exc: Exception | None = None
+        for attempt in range(1, YTMUSIC_ADD_ITEMS_MAX_RETRIES + 1):
+            try:
+                album = self.yt.get_album(browse_id)
+                audio_playlist_id = album.get("audioPlaylistId")
+                if not audio_playlist_id:
+                    return False
+                self.yt.rate_playlist(audio_playlist_id, "LIKE")
+                return True
+            except Exception as exc:
+                if _classify_exception(exc) is YTMusicFatalError:
+                    raise YTMusicFatalError(
+                        f"Failed to save album {browse_id}: "
+                        f"{type(exc).__name__}: {exc}"
+                    ) from exc
+                last_exc = exc
+                if attempt < YTMUSIC_ADD_ITEMS_MAX_RETRIES:
+                    time.sleep(delay)
+                    delay *= 2
+        raise YTMusicTransientError(
+            f"save_album exhausted retries for {browse_id} (last exc: {last_exc!r})"
+        )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,33 @@
+"""Shared pytest fixtures."""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Make the package importable when running `pytest` from backend/ without an
+# editable install in the active interpreter.
+_BACKEND_SRC = Path(__file__).resolve().parents[1] / "src"
+if str(_BACKEND_SRC) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_SRC))
+
+from spotify_to_ytmusic.core.ytmusic_client import YTMusicClient  # noqa: E402
+
+
+@pytest.fixture
+def ytmusic_client() -> YTMusicClient:
+    """A YTMusicClient with __init__ bypassed and `.yt` swapped for a mock.
+
+    Avoids touching the real YT Music API or filesystem during unit tests.
+    """
+    client = object.__new__(YTMusicClient)
+    client.yt = MagicMock()
+    return client
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """Make time.sleep a no-op so retry/backoff loops don't slow tests down."""
+    import time as _time
+
+    monkeypatch.setattr(_time, "sleep", lambda *_a, **_k: None)

--- a/backend/tests/test_migrator.py
+++ b/backend/tests/test_migrator.py
@@ -1,0 +1,172 @@
+"""Tests for the Migrator: per-playlist/album fatal isolation; job-aborting search fatals."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from spotify_to_ytmusic.core.migrator import Migrator
+from spotify_to_ytmusic.core.models import (
+    Album,
+    Playlist,
+    PlaylistSummary,
+    Track,
+)
+from spotify_to_ytmusic.core.track_cache import TrackCache
+from spotify_to_ytmusic.core.ytmusic_client import (
+    YTMusicFatalError,
+    YTMusicTransientError,
+)
+
+
+def _make_migrator(tmp_path) -> tuple[Migrator, MagicMock, MagicMock]:
+    spotify = MagicMock()
+    ytmusic = MagicMock()
+    cache = TrackCache(tmp_path / "cache.json")
+    migrator = Migrator(spotify=spotify, ytmusic=ytmusic, cache=cache)
+    return migrator, spotify, ytmusic
+
+
+def _track(name: str, spot_id: str = "") -> Track:
+    return Track(
+        name=name,
+        artist="A",
+        album="ALB",
+        duration_ms=1000,
+        spotify_id=spot_id,
+    )
+
+
+def _summary(pid: str, name: str) -> PlaylistSummary:
+    return PlaylistSummary(
+        id=pid, name=name, description="d", track_count=1, owner_id="u", is_own=True
+    )
+
+
+# --- Playlist migration --------------------------------------------------
+
+
+def test_migrate_playlist_records_fatal_in_report_and_continues(tmp_path):
+    migrator, spotify, ytmusic = _make_migrator(tmp_path)
+
+    spotify.get_current_user_id.return_value = "u"
+    spotify.list_playlist_summaries.return_value = [
+        _summary("p1", "First"),
+        _summary("p2", "Second"),
+    ]
+    spotify.load_playlist_by_id.side_effect = lambda pid, name, desc: Playlist(
+        id=pid, name=name, description=desc, tracks=[_track("Song", spot_id=pid + "_t")]
+    )
+    ytmusic.search_song.return_value = "VID_X"
+
+    # First playlist hits a fatal in create_playlist; second succeeds.
+    ytmusic.create_playlist.side_effect = [
+        YTMusicFatalError("creation forbidden"),
+        "PL_yt_2",
+    ]
+
+    migrator.migrate_playlists()
+
+    assert len(migrator.report.playlists) == 2
+    failed, ok = migrator.report.playlists
+    assert failed.name == "First"
+    assert failed.yt_playlist_id is None
+    assert failed.found == 0
+    assert failed.error is not None
+    assert "creation forbidden" in failed.error
+
+    assert ok.name == "Second"
+    assert ok.yt_playlist_id == "PL_yt_2"
+    assert ok.error is None
+    assert ok.found == 1
+
+
+def test_migrate_playlist_records_transient_exhaustion_in_report(tmp_path):
+    migrator, spotify, ytmusic = _make_migrator(tmp_path)
+
+    spotify.get_current_user_id.return_value = "u"
+    spotify.list_playlist_summaries.return_value = [_summary("p1", "Only")]
+    spotify.load_playlist_by_id.return_value = Playlist(
+        id="p1", name="Only", description="d", tracks=[_track("S")]
+    )
+    ytmusic.search_song.return_value = "VID_X"
+    ytmusic.create_playlist.side_effect = YTMusicTransientError("retries done")
+
+    migrator.migrate_playlists()
+
+    [result] = migrator.report.playlists
+    assert result.error is not None
+    assert "transient" in result.error
+    assert result.yt_playlist_id is None
+    assert result.found == 0
+
+
+def test_search_song_fatal_aborts_job(tmp_path):
+    migrator, spotify, ytmusic = _make_migrator(tmp_path)
+
+    spotify.get_current_user_id.return_value = "u"
+    spotify.list_playlist_summaries.return_value = [_summary("p1", "Only")]
+    spotify.load_playlist_by_id.return_value = Playlist(
+        id="p1", name="Only", description="d", tracks=[_track("S", spot_id="t1")]
+    )
+    ytmusic.search_song.side_effect = YTMusicFatalError("auth expired")
+
+    with pytest.raises(YTMusicFatalError, match="auth expired"):
+        migrator.migrate_playlists()
+
+    # The aborted playlist did not reach the report (we never got past the
+    # track loop). The fact that the exception propagates is the contract.
+    assert migrator.report.playlists == []
+
+
+# --- Album migration -----------------------------------------------------
+
+
+def test_migrate_album_records_fatal_from_save_in_report_and_continues(tmp_path):
+    migrator, spotify, ytmusic = _make_migrator(tmp_path)
+
+    spotify.get_saved_albums.return_value = [
+        Album(name="In Rainbows", artist="Radiohead", spotify_id="a1"),
+        Album(name="Currents", artist="Tame Impala", spotify_id="a2"),
+    ]
+    ytmusic.search_album.return_value = {"browseId": "BR"}
+    ytmusic.save_album.side_effect = [
+        YTMusicFatalError("forbidden"),
+        True,
+    ]
+
+    migrator.migrate_albums()
+
+    assert len(migrator.report.albums) == 2
+    failed, ok = migrator.report.albums
+    assert failed.label == "Radiohead - In Rainbows"
+    assert failed.error is not None
+    assert "forbidden" in failed.error
+    assert ok.label == "Tame Impala - Currents"
+    assert ok.error is None
+    assert ok.status == "saved"
+
+
+def test_migrate_album_records_fatal_from_search_in_report_and_continues(tmp_path):
+    migrator, spotify, ytmusic = _make_migrator(tmp_path)
+
+    spotify.get_saved_albums.return_value = [
+        Album(name="In Rainbows", artist="Radiohead", spotify_id="a1"),
+        Album(name="Currents", artist="Tame Impala", spotify_id="a2"),
+    ]
+    ytmusic.search_album.side_effect = [
+        YTMusicFatalError("search forbidden"),
+        {"browseId": "BR"},
+    ]
+    ytmusic.save_album.return_value = True
+
+    migrator.migrate_albums()
+
+    assert len(migrator.report.albums) == 2
+    failed = migrator.report.albums[0]
+    assert failed.label == "Radiohead - In Rainbows"
+    assert failed.status == "not found"
+    assert failed.error is not None
+    assert "search forbidden" in failed.error
+
+    ok = migrator.report.albums[1]
+    assert ok.error is None
+    assert ok.status == "saved"

--- a/backend/tests/test_ytmusic_client.py
+++ b/backend/tests/test_ytmusic_client.py
@@ -1,0 +1,201 @@
+"""Tests for YTMusicClient: typed exceptions, transient retry, fatal propagation."""
+import json
+
+import pytest
+import requests
+from ytmusicapi.exceptions import YTMusicServerError, YTMusicUserError
+
+from spotify_to_ytmusic.core.ytmusic_client import (
+    YTMusicFatalError,
+    YTMusicTransientError,
+    _classify_exception,
+)
+
+
+# --- _classify_exception -------------------------------------------------
+
+
+def test_classify_jsondecode_is_transient():
+    exc = json.JSONDecodeError("Expecting value", "", 0)
+    assert _classify_exception(exc) is YTMusicTransientError
+
+
+def test_classify_connection_error_is_transient():
+    assert (
+        _classify_exception(requests.exceptions.ConnectionError("dns fail"))
+        is YTMusicTransientError
+    )
+
+
+def test_classify_timeout_is_transient():
+    assert (
+        _classify_exception(requests.exceptions.Timeout("slow"))
+        is YTMusicTransientError
+    )
+
+
+def test_classify_http_5xx_is_transient():
+    response = requests.Response()
+    response.status_code = 503
+    err = requests.exceptions.HTTPError(response=response)
+    assert _classify_exception(err) is YTMusicTransientError
+
+
+def test_classify_http_4xx_is_fatal():
+    response = requests.Response()
+    response.status_code = 401
+    err = requests.exceptions.HTTPError(response=response)
+    assert _classify_exception(err) is YTMusicFatalError
+
+
+def test_classify_user_error_is_fatal():
+    assert _classify_exception(YTMusicUserError("bad request")) is YTMusicFatalError
+
+
+def test_classify_server_error_is_transient():
+    assert _classify_exception(YTMusicServerError("500")) is YTMusicTransientError
+
+
+def test_classify_unknown_is_fatal():
+    assert _classify_exception(ValueError("???")) is YTMusicFatalError
+
+
+# --- create_playlist -----------------------------------------------------
+
+
+def test_create_playlist_propagates_fatal_when_yt_create_raises_user_error(
+    ytmusic_client,
+):
+    ytmusic_client.yt.create_playlist.side_effect = YTMusicUserError("forbidden")
+    with pytest.raises(YTMusicFatalError, match="Failed to create playlist"):
+        ytmusic_client.create_playlist("My PL", "desc", ["v1"])
+
+
+def test_create_playlist_propagates_fatal_when_id_is_empty(ytmusic_client):
+    ytmusic_client.yt.create_playlist.return_value = ""
+    with pytest.raises(YTMusicFatalError, match="invalid id"):
+        ytmusic_client.create_playlist("My PL", "desc", ["v1"])
+
+
+def test_create_playlist_propagates_fatal_when_id_is_dict(ytmusic_client):
+    # ytmusicapi sometimes returns a status dict instead of an id on failure.
+    ytmusic_client.yt.create_playlist.return_value = {"status": "STATUS_FAILED"}
+    with pytest.raises(YTMusicFatalError, match="invalid id"):
+        ytmusic_client.create_playlist("My PL", "desc", ["v1"])
+
+
+def test_create_playlist_succeeds_when_chunk_throws_then_recovers(ytmusic_client):
+    ytmusic_client.yt.create_playlist.return_value = "PL_real"
+    # First add attempt: transient JSONDecodeError. Second: success.
+    ytmusic_client.yt.add_playlist_items.side_effect = [
+        json.JSONDecodeError("Expecting value", "", 0),
+        {"status": "STATUS_SUCCEEDED"},
+    ]
+    pid = ytmusic_client.create_playlist("PL", "d", ["v1", "v2"])
+    assert pid == "PL_real"
+    assert ytmusic_client.yt.add_playlist_items.call_count == 2
+
+
+def test_create_playlist_propagates_fatal_from_chunk_immediately(ytmusic_client):
+    """A fatal during add_playlist_items must NOT burn the retry budget."""
+    ytmusic_client.yt.create_playlist.return_value = "PL_real"
+    ytmusic_client.yt.add_playlist_items.side_effect = YTMusicUserError("forbidden")
+    with pytest.raises(YTMusicFatalError, match="Failed to add chunk"):
+        ytmusic_client.create_playlist("PL", "d", ["v1"])
+    # Exactly one call: classified fatal, raised on first attempt.
+    assert ytmusic_client.yt.add_playlist_items.call_count == 1
+
+
+# --- _add_chunk_with_retry -----------------------------------------------
+
+
+def test_add_chunk_raises_transient_after_max_retries(ytmusic_client):
+    # add_playlist_items keeps returning a non-success body — exhausts retries.
+    ytmusic_client.yt.add_playlist_items.return_value = None
+    with pytest.raises(YTMusicTransientError, match="exhausted retries"):
+        ytmusic_client._add_chunk_with_retry("PL", ["v1"])
+    # Default YTMUSIC_ADD_ITEMS_MAX_RETRIES = 5
+    assert ytmusic_client.yt.add_playlist_items.call_count == 5
+
+
+def test_add_chunk_recovers_after_one_transient_failure(ytmusic_client):
+    ytmusic_client.yt.add_playlist_items.side_effect = [
+        requests.exceptions.ConnectionError("blip"),
+        {"status": "STATUS_SUCCEEDED"},
+    ]
+    # Should not raise.
+    ytmusic_client._add_chunk_with_retry("PL", ["v1"])
+    assert ytmusic_client.yt.add_playlist_items.call_count == 2
+
+
+# --- save_album ----------------------------------------------------------
+
+
+def test_save_album_recovers_from_transient(ytmusic_client):
+    ytmusic_client.yt.get_album.side_effect = [
+        json.JSONDecodeError("Expecting value", "", 0),
+        {"audioPlaylistId": "AP_1"},
+    ]
+    ytmusic_client.yt.rate_playlist.return_value = None
+    assert ytmusic_client.save_album("BR_1") is True
+    assert ytmusic_client.yt.get_album.call_count == 2
+    ytmusic_client.yt.rate_playlist.assert_called_once_with("AP_1", "LIKE")
+
+
+def test_save_album_returns_false_when_no_audio_playlist_id(ytmusic_client):
+    ytmusic_client.yt.get_album.return_value = {"audioPlaylistId": None}
+    assert ytmusic_client.save_album("BR_1") is False
+    ytmusic_client.yt.rate_playlist.assert_not_called()
+
+
+def test_save_album_propagates_fatal(ytmusic_client):
+    ytmusic_client.yt.get_album.side_effect = YTMusicUserError("forbidden")
+    with pytest.raises(YTMusicFatalError, match="Failed to save album"):
+        ytmusic_client.save_album("BR_1")
+    assert ytmusic_client.yt.get_album.call_count == 1
+
+
+def test_save_album_raises_transient_after_max_retries(ytmusic_client):
+    ytmusic_client.yt.get_album.side_effect = (
+        requests.exceptions.ConnectionError("blip")
+    )
+    with pytest.raises(YTMusicTransientError, match="exhausted retries"):
+        ytmusic_client.save_album("BR_1")
+    assert ytmusic_client.yt.get_album.call_count == 5
+
+
+# --- _search_with_retries ------------------------------------------------
+
+
+def test_search_skips_query_on_transient_then_returns_match(ytmusic_client):
+    """First query throws transient, second query succeeds with a match."""
+    ytmusic_client.yt.search.side_effect = [
+        requests.exceptions.ConnectionError("blip"),
+        [
+            {
+                "videoId": "VID_1",
+                "artists": [{"name": "Radiohead"}],
+            }
+        ],
+    ]
+    result = ytmusic_client.search_song("Karma Police", "Radiohead")
+    assert result == "VID_1"
+    assert ytmusic_client.yt.search.call_count == 2
+
+
+def test_search_propagates_fatal_immediately(ytmusic_client):
+    ytmusic_client.yt.search.side_effect = YTMusicUserError("forbidden")
+    with pytest.raises(YTMusicFatalError, match="Search failed"):
+        ytmusic_client.search_song("Karma Police", "Radiohead")
+    # Stopped on the first query — fatal short-circuits.
+    assert ytmusic_client.yt.search.call_count == 1
+
+
+def test_search_returns_none_when_all_queries_transient(ytmusic_client):
+    """If every query variant fails transient, return None (no match)."""
+    ytmusic_client.yt.search.side_effect = (
+        requests.exceptions.ConnectionError("blip")
+    )
+    assert ytmusic_client.search_song("Karma Police", "Radiohead") is None
+    # _build_queries dedups; with this artist/title it produces 3 variants.
+    assert ytmusic_client.yt.search.call_count >= 1


### PR DESCRIPTION
## Summary

- Add `YTMusicTransientError` and `YTMusicFatalError` to `ytmusic_client.py` plus a `_classify_exception` helper that maps `json.JSONDecodeError`, `requests.{ConnectionError,Timeout,ChunkedEncodingError}`, `requests.HTTPError` (5xx) and `YTMusicServerError` to transient; `YTMusicUserError`, `HTTPError` 4xx and anything unknown to fatal.
- `create_playlist` now returns `str` (never `None`) and raises `YTMusicFatalError` on creation failure or invalid id — closes the bug where `_add_chunk_with_retry(None, ...)` burned the entire retry budget on an empty id.
- `_add_chunk_with_retry` raises `YTMusicTransientError` after exhausting retries and propagates fatals immediately on the first attempt (no retry burn). Same pattern for `save_album` and `_search_with_retries` (transient → skip query variant, fatal → propagate).
- `Migrator` catches `YTMusicFatalError` per playlist and per album, records the reason via new `error: str | None` fields on `PlaylistMigrationResult` / `AlbumMigrationResult`, and continues with the next item. Fatals from `search_song` still abort the whole job (auth/quota expired mid-run is unrecoverable; `TrackCache` protects already-resolved hits on re-run).
- New `backend/tests/` suite (27 cases, mocked) covers the classifier, every public-method failure path, and the Migrator's per-item isolation. CLAUDE.md gotchas section documents the new contract.

## Closes

Closes #63

## Test plan

- [x] `cd backend && python -m pytest tests/` — 27/27 passing
- [x] `python -m ruff check backend/src/spotify_to_ytmusic/core/{ytmusic_client.py,migrator.py,models.py} backend/tests/` — clean
- [x] `python backend/main.py --help` — imports clean, no breakage
- [ ] Manual: trigger an auth error mid-run (e.g. corrupt `browser.json` after start) and verify the job aborts cleanly with the original `YTMusicFatalError` message instead of a stack of "0 tracks migrated" rows