### PR TITLE
docs: refresh after sprint #58-#63 and harden resolve-issue skill

### DIFF
--- a/.claude/commands/resolve-issue.md
+++ b/.claude/commands/resolve-issue.md
@@ -1,89 +1,185 @@
-Sigue este procedimiento exacto para resolver las issues $ARGUMENTS del repositorio vsrd-sftw/spotify-to-ytmusic:
+Sigue este procedimiento exacto para resolver las issues $ARGUMENTS del repositorio vsrd-sftw/spotify-to-ytmusic.
+
+**Antes de empezar:** lee `CLAUDE.md` y `CONTRIBUTING.md` si no los tienes en contexto. La sección "Roadmap state" de `CLAUDE.md` y los gotchas son obligatorios — son el resultado de auditorías y cambios que hicimos en sprints anteriores y siguen siendo el contrato del proyecto.
 
 ## 1. Entrar en plan mode
 
-Usa la herramienta EnterPlanMode antes de hacer cualquier otra cosa.
+Usa la herramienta EnterPlanMode antes de hacer cualquier otra cosa. Si vas a tocar varios bloques (frontend + backend, varias áreas), prefiere planificar todo junto antes de implementar — ahorra rondas de revisión.
 
 ## 2. Leer las issues
 
-Para cada número en $ARGUMENTS, ejecuta:
+Para cada número en $ARGUMENTS:
+
 ```
 gh issue view <número> --repo vsrd-sftw/spotify-to-ytmusic
 ```
 
-## 3. Generar un plan
+Y, si la issue cita dependencias (`Dependencias: #N`), léelas también — aunque ya estén cerradas, suelen documentar decisiones que afectan al diseño actual. La existencia de un campo no significa que esté implementado: verifica en el código antes de asumir.
 
-Dentro del plan mode, analiza las issues y elabora un plan detallado:
-- Qué archivos hay que crear o modificar
-- Qué tests hay que escribir
-- Cómo encaja con la arquitectura existente (CLAUDE.md)
-- Orden de implementación
+## 3. Verificar el estado real del repo
 
-Sal del plan mode con ExitPlanMode y pide confirmación antes de continuar.
+Las issues describen lo que **debería** existir, no lo que existe. Antes de planificar, comprueba:
 
-## 4. Crear rama
+- Issues vecinas ya cerradas en el área que tocas (`gh issue list --state closed --limit 20 --json number,title --search "<area>"`).
+- Archivos que la issue dice que vas a crear: si ya existen, alguien empezó — entiende qué hay antes de pisarlo.
+- `git log -20 --oneline` y `git log --grep="<scope>" --oneline` para ver si hay commits recientes relacionados.
 
-Crea una rama con nombre descriptivo siguiendo el patrón `feat/<scope>-<descripción-corta>` o `fix/<scope>-<descripción-corta>`:
+Esta verificación evita reescribir trabajo ya hecho y detecta drift entre la issue y la realidad.
+
+## 4. Generar un plan
+
+Dentro del plan mode, elabora un plan detallado:
+
+- **Archivos a crear/modificar** con paths concretos.
+- **Tests**: para feature, tests unitarios del happy path + casos límite. Para fix, test de regresión que falle antes y pase después.
+- **Encaje arquitectónico** según `CLAUDE.md`:
+  - Backend `core/` no hace `print()` — emite `MigrationEvent`.
+  - Reusa `SpotifyClient` / `YTMusicClient` / `TrackCache`. Nada de `spotipy`/`ytmusicapi` directos en código nuevo.
+  - Tunables en `core/config.py`.
+  - Frontend: selección via `SelectionContext`, navegación via react-router-dom, focus via `useAutoFocusHeading`, fetch via `lib/http.ts`.
+  - **No bootstrappees** `api/` (FastAPI) ni el frontend salvo que la issue lo pida.
+- **Gotchas relevantes**: revisa la sección de `CLAUDE.md` y comprueba si tu cambio toca alguna (forma del payload de Spotify, `duplicates=True`, retry-on-empty-body, MSW path patterns, cierre limpio de WS, taxonomía de errores YT, etc.).
+- **Orden de implementación**: si una issue depende de otra y vas a hacer ambas, decide qué se hace antes y por qué.
+
+Sal del plan mode con ExitPlanMode y **pide confirmación** al usuario antes de continuar. No empieces a tocar archivos hasta que confirme.
+
+## 5. Crear rama
+
+Patrón obligatorio:
+
+- `feat/<scope>-<descripción-corta>` para features
+- `fix/<scope>-<descripción-corta>` para bugs
+- `chore/<scope>-<descripción-corta>` para chores
+- `refactor/<scope>-<descripción-corta>` para refactors
+
+Si vas a resolver varias issues en una sola PR (acumular hardening, completar un epic), usa `feat/<scope>-batch-<rangos>` (ej. `feat/frontend-batch-58-62`).
+
 ```
 git checkout -b <nombre-rama>
 ```
 
-## 5. Implementar
+Verifica que partes de `main` actualizado: `git fetch origin && git checkout main && git pull && git checkout -b …`.
 
-Trabaja issue a issue siguiendo el plan. Respeta el Definition of Done del CLAUDE.md:
-- Sin `print()` en `core/`, usar eventos
-- Tests para todo comportamiento nuevo; tests de regresión para bugs
-- Tunables en `config.py`, no hardcodeados
-- No bootstrapear el servidor FastAPI ni el frontend salvo que la issue lo pida explícitamente
+## 6. Implementar
 
-## 6. Comprobar tests
+Trabaja issue a issue siguiendo el plan. Reglas innegociables:
 
-Ejecuta los tests y asegúrate de que todos pasan:
-- Backend: `pytest` desde `backend/`
-- Frontend: `pnpm exec vitest run` desde `frontend/` (si hay cambios en frontend)
+- **Definition of Done** del CLAUDE.md / CONTRIBUTING.md aplica entero.
+- **Strings de la CLI en español**, código y comentarios en inglés.
+- **Conventional Commits con scope** (`feat(cli)`, `fix(ytmusic)`, `chore(frontend)`, …).
+- **Sin comentarios que repiten el código**. Solo comentarios cuando expliquen un porqué no obvio (los gotchas de CLAUDE.md son el listón).
+- **Sin abstracciones prematuras**. Tres líneas similares > una abstracción que aún no se necesita.
 
-No sigas si hay tests en rojo.
+Si descubres algo que la issue no cubre pero es necesario para no dejar el código a medias, **dilo** (en la PR o en el chat) en vez de hacerlo silenciosamente.
 
-## 7. Comprobar si el CI pasaría
+## 7. Comprobar tests
 
-Revisa el workflow de CI ejecutando localmente lo que haría el pipeline:
+Antes de commitear, **todo verde**:
+
+- **Backend** (si tocaste backend):
+  ```bash
+  cd backend && pytest
+  ```
+- **Frontend** (si tocaste frontend):
+  ```bash
+  cd frontend && pnpm test:run
+  ```
+- **Lint y format frontend** (CI los corre):
+  ```bash
+  cd frontend && pnpm lint && pnpm format:check
+  ```
+- **Build frontend** (asegura que el `tsc -b` pasa):
+  ```bash
+  cd frontend && pnpm build
+  ```
+
+Si hay rojo, **no continues**. Diagnostica y arregla. No pongas `// @ts-ignore`, no comentes tests, no uses `--no-verify` en commits.
+
+## 8. Comprobar el CI manualmente
+
 ```
 gh workflow list --repo vsrd-sftw/spotify-to-ytmusic
 ```
-Identifica los pasos (lint, type-check, tests) y ejecútalos. Si algo falla, corrígelo antes de continuar.
 
-## 8. Commit y push
+Identifica el workflow del área tocada (frontend/backend). Si lo que el workflow corre no coincide con lo que has corrido tú localmente, replícalo. Es más barato fallar local que ver el rojo en GitHub.
 
-Agrupa los cambios en un commit por issue (o uno conjunto si están muy ligadas). Usa Conventional Commits con scope:
-```
-git add <archivos específicos>
-git commit -m "feat(<scope>): <descripción corta>
+## 9. Commit y push
 
-<detalle si es necesario>"
+Un commit por issue cuando estén bien delimitadas; un commit por bloque coherente cuando varias issues vayan juntas (ej. "frontend hardening batch"). **Mensaje en inglés, en imperativo**:
+
+```bash
+git add <archivos específicos>     # nunca "git add ."
+git commit -m "feat(<scope>): <descripción corta en imperativo>
+
+<cuerpo opcional explicando el porqué>"
 git push -u origin <nombre-rama>
 ```
 
-## 9. Crear PR
+Si el cuerpo es multilínea, usa heredoc:
 
-Crea la PR con:
+```bash
+git commit -m "$(cat <<'EOF'
+feat(scope): short summary
+
+Why this change exists, not what it does. Reference the issue if useful.
+Mention any decisions you made that diverge from the issue's plan.
+EOF
+)"
+```
+
+**Nunca** uses `Co-Authored-By: Claude` ni menciones IA en el commit/PR.
+
+## 10. Crear PR
+
 ```
 gh pr create --title "<tipo>(<scope>): <descripción>" --body "..."
 ```
 
-El body debe seguir exactamente esta estructura (sin mencionar Claude ni herramientas de IA):
+El body sigue **exactamente** esta estructura:
 
-```
+```markdown
 ## Summary
 
-- Bullet point por cambio relevante
+- Bullet por cambio relevante (qué cambia, no cómo)
+- Si hay decisiones de diseño que diverjan de la issue, anótalas aquí
 
 ## Closes
 
-Closes #<número1>, Closes #<número2>
+Closes #<n1>, Closes #<n2>
 
 ## Test plan
 
-- [ ] Ítem de verificación manual o automatizada
+- [ ] `pytest` desde `backend/` en verde (si tocó backend)
+- [ ] `pnpm test:run` en `frontend/` en verde (si tocó frontend)
+- [ ] `pnpm lint && pnpm format:check && pnpm build` en `frontend/` en verde
+- [ ] Verificación manual: <comando o pasos concretos para probarlo>
 ```
 
-El campo `Closes #N` hace que GitHub cierre las issues automáticamente al mergear.
+Cada `Closes #N` cierra la issue automáticamente al mergear. **Una línea por issue cerrada**, no las metas en una sola línea con comas.
+
+No menciones a Claude ni a herramientas de IA en el PR.
+
+## 11. Tras crear la PR
+
+1. Devuelve la URL de la PR al usuario.
+2. Si CI falla, **investígalo y arréglalo en la misma rama** — no abras una PR nueva.
+3. Si los criterios de aceptación de la issue requieren verificación manual con el backend real, déjalo claro en el "Test plan" como bloqueante hasta que el server FastAPI exista (issues #67–#70).
+
+## Cuándo escalar / parar
+
+Para y consulta antes de continuar si:
+
+- La issue contradice la arquitectura actual (`CLAUDE.md`) y no estás seguro de cuál tiene razón.
+- Encuentras un bug grave fuera del scope que bloquea la issue. Documéntalo y pregunta antes de mezclar fixes.
+- El alcance real de la issue resulta ser mucho mayor de lo que el body sugería. Mejor abrir una segunda issue que entregar algo a medias.
+
+## Anti-patrones que ya nos hemos encontrado
+
+No los repitas:
+
+- `except Exception: return None` en `ytmusic_client.py` — ya hubo una issue (#63) específica para arrancar eso. Si caes en la tentación, pregúntate si lo que tienes delante es transient o fatal.
+- `useState(new Set())` para selección en una página — la selección vive en `SelectionContext` (#58). Crear nuevo estado local rompe el flujo Library → Migrate.
+- `useEffect(() => { document.querySelector('h2')?.focus() })` global en `App.tsx` — el focus va por página con `useAutoFocusHeading` (#60).
+- WebSocket que reconecta en cualquier `onclose` — el cierre limpio (1000/1005/wasClean) se considera final. Reconectar en cierre limpio causó un bucle infinito en migración con MSW.
+- Importar `fetch` directamente desde un feature — ve por `lib/http.ts` para heredar el timeout de 15 s.
+- Crear archivos de planificación / docs intermedios sin que el usuario los pida — trabaja desde el chat y los archivos de código.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,26 @@ live in `README.md` and `backend/README.md`.
 ## What this is
 
 CLI that migrates a Spotify library (playlists + saved albums) to YouTube
-Music. Monorepo: `backend/` is the Python package and CLI; `frontend/` is
-a Vite/React 19 + TanStack Query scaffolding being built incrementally
-issue-by-issue (no real UI yet, just typed contracts and MSW stubs of the
-planned API). There is also an empty `backend/src/spotify_to_ytmusic/api/`
-reserved for a future FastAPI server. **Don't expand the frontend or
-bootstrap the API server beyond what the current task asks** — there is
-no live HTTP backend today, the CLI is the only working entry point.
+Music. Monorepo:
+
+- **`backend/`** — Python package and CLI. Production-ready for the CLI
+  flow; emits typed `MigrationEvent`s ready for an HTTP/WS transport.
+- **`frontend/`** — Vite/React 19 + TanStack Query + react-router-dom 7.
+  Full UI built page by page (Connect, Library, Migrate, Reports). Talks
+  to the backend through a `*/api/...` contract that **only MSW serves
+  today** — there is no live HTTP backend yet.
+- **`backend/src/spotify_to_ytmusic/api/`** — empty placeholder reserved
+  for the FastAPI server (issues #67–#70 will fill it in).
+
+**The integration gap is the next big piece of work.** Until then:
+
+- CLI is the only end-to-end working flow (`python backend/main.py …`).
+- Frontend "works" against MSW mocks: it renders, navigates, validates
+  forms, exercises hooks/tests — but Connect doesn't actually OAuth,
+  Migrate doesn't actually run a job, and Reports list/detail are
+  fixtures, not files on disk.
+- **Don't bootstrap the FastAPI server (`api/`) unless the task explicitly
+  asks for it.** Same for new top-level frontend features.
 
 ## Where to run things
 
@@ -99,6 +112,31 @@ in git history, so check the relevant commit before "improving" any of this.
   match in the browser worker but not in Vitest's Node environment, so
   handler tests silently fall through to `onUnhandledRequest: 'error'`. See
   [handlers.ts](frontend/src/test/msw/handlers.ts).
+- **WebSocket reconnection only fires on abnormal closes.** `WsConnection.onclose`
+  short-circuits to `closed` (no reconnect) when `ev.wasClean`, `ev.code === 1000`
+  or `ev.code === 1005`. The MSW handler closes the WS cleanly after streaming
+  the fixture batch — without this guard the migrate page enters an infinite
+  reopen loop. See [ws.ts](frontend/src/lib/ws.ts) and the regression test
+  `does not reconnect when the server closes the stream cleanly` in
+  [useMigrationEvents.test.tsx](frontend/src/hooks/useMigrationEvents.test.tsx).
+- **Selection lives in `SelectionContext`, not in page-local state.** Each
+  page used to call `useSelection` independently, which silently reset the
+  user's choices when navigating Library → Migrate. Read/write through
+  [`useSelectionContext`](frontend/src/contexts/useSelectionContext.ts);
+  don't introduce new local `useState(new Set())` for picked playlists/albums.
+- **Routing is real (`react-router-dom` v7).** Use `<Link>`/`<NavLink>` and
+  `useNavigate` — don't reintroduce a `section` enum or imperative
+  `setSection` calls. Deep links like `/reports/:id` must keep working on
+  refresh.
+- **Per-page focus management uses `useAutoFocusHeading`.** The old global
+  `useEffect` in `App.tsx` that searched for any `h2/h3` was removed.
+  Each page declares its own heading `ref` and calls the hook on mount.
+  Don't reintroduce a cross-page focus side-effect.
+- **`http.ts` enforces a 15 s default timeout** via `AbortSignal.timeout`.
+  Override per call with `http.get(path, { timeoutMs })`. A timed-out
+  request rejects with a `DOMException` whose `name` is `TimeoutError`
+  (or `AbortError` if the caller aborted). Don't wrap `fetch` directly
+  from feature code — go through `http`.
 
 ## Style and conventions
 
@@ -162,14 +200,25 @@ backend/src/spotify_to_ytmusic/
         headers_parser.py                         # Browser headers → ytmusicapi
 backend/data/                                     # Runtime state, gitignored
 
-frontend/                                         # Vite + React 19 + TanStack Query
+frontend/                                         # Vite + React 19 + TanStack Query + react-router-dom 7
     public/mockServiceWorker.js                   # MSW worker (generated, committed)
     src/
-        main.tsx                                  # Boots MSW in dev, then mounts App
+        main.tsx                                  # MSW + ErrorBoundary + BrowserRouter + QueryClient
+        App.tsx                                   # <Routes> only — no section enum
         types/api.ts                              # TS mirror of backend models + events
+        contexts/                                 # SelectionContext (cross-page selection)
+        components/
+            layout/                               # AppShell, Header, Footer, ErrorBoundary, ConnectionStatus
+            ui/                                   # Button, Toast, Card, Input, Skeleton, …
+            library/                              # Tabs, SelectionSummary
+            migrate/                              # PlaylistProgress, AlbumProgress, NotFound, …
+        pages/                                    # Connect, Library, Migrate, Reports/{List,Detail}
+        features/                                 # auth/, library/, migrate/, reports/ — TanStack hooks
+        hooks/                                    # useAutoFocusHeading, useFocusTrap, useMigrationEvents
+        lib/                                      # http (timeout-aware), ws (clean-close aware), query-client, download
         test/setup.ts                             # Vitest + MSW server lifecycle
         test/msw/                                 # handlers, fixtures, server, browser
-        lib/query-client.ts                       # TanStack Query client
+backend/tests/                                    # pytest suite (migrator, ytmusic_client) — incomplete; see #66
 ```
 
 ## Plan files
@@ -177,3 +226,25 @@ frontend/                                         # Vite + React 19 + TanStack Q
 There's a plan file at `.claude/plans/` from a previous session. Check it
 for recent decisions before starting a new task — it may have context that
 hasn't made it back to the READMEs yet.
+
+## Roadmap state
+
+The backlog after the May 2026 audit is grouped into four blocks (issues
+#58–#74). State as of the last update:
+
+- **Frontend hardening (#58–#62):** all merged. Selection persists across
+  pages, react-router-dom drives navigation, per-page focus management,
+  WS reducer + rAF-coalesced scroll, lowercase folders, ErrorBoundary
+  global, `http` with timeout.
+- **Backend correctness (#63):** merged. Typed YT Music exceptions.
+- **Backend correctness (#64–#66):** open. Failure events, atomic
+  report writes, full pytest suite.
+- **Integration / FastAPI (#67–#71):** open. Bootstrap, auth, read-only
+  routes, migrate POST + WS, OpenAPI-generated TS types + Vite proxy.
+  **This is the unlock for the frontend's mock-only state.**
+- **Desktop / Tauri (#72–#74):** open. PyInstaller sidecar, Tauri scaffold,
+  OAuth + auto-updater.
+
+The critical path to a real (non-mock) end-to-end app is **#67 → #68 →
+#69 → #70 → #71**. Until #71 lands, the frontend talks to MSW: Connect
+buttons, Migrate jobs, and Reports come from fixtures, not the backend.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,26 @@ Migrate your Spotify library to YouTube Music — playlists and saved albums inc
 
 This is a monorepo:
 
-- **`backend/`** — Python package with the migration logic, CLI, and (planned) FastAPI server.
-- **`frontend/`** — Web UI (planned: Vite + React + TypeScript).
+- **`backend/`** — Python package with the migration logic and CLI. Ships
+  a working CLI today; emits typed events ready for an HTTP/WebSocket
+  transport. The FastAPI server (`api/`) is reserved for issues #67–#70.
+- **`frontend/`** — Vite + React 19 + TypeScript + TanStack Query +
+  react-router-dom 7. Full UI built page by page (Connect, Library,
+  Migrate, Reports). Currently runs against [MSW](https://mswjs.io)
+  mocks — there is no live HTTP backend yet, so OAuth, migration jobs
+  and reports listing are simulated until issues #67–#71 land.
+
+## Status
+
+- **Working today:** the CLI (`python backend/main.py …`) does the full
+  Spotify → YouTube Music migration end-to-end and writes a JSON report.
+- **Working in dev mode:** `pnpm dev` boots the frontend with MSW
+  mocking every `/api/*` call. You can navigate, select playlists,
+  trigger a "migration" (fixture event stream) and download a fixture
+  report. None of it talks to a real server.
+- **Next big block of work:** issues #67–#71 (FastAPI server + OpenAPI
+  types + Vite proxy). After that, #72–#74 wrap everything in a Tauri 2
+  desktop app.
 
 ## Features
 
@@ -17,6 +35,9 @@ This is a monorepo:
   the slow YouTube Music searches
 - JSON report with statistics and a list of items not found
 - Event-driven `Migrator` ready to drive a UI over WebSockets
+- Typed exception layer (`YTMusicTransientError` vs `YTMusicFatalError`)
+  so transient throttling retries silently while fatal failures (auth,
+  permanent 4xx) propagate and are recorded in the report
 
 ## Quick start
 
@@ -80,10 +101,23 @@ spotify-to-ytmusic/
 │           │   └── report.py       # JSON report serialization
 │           ├── cli/                # Console entry point
 │           │   └── __init__.py
-│           └── api/                # (planned) FastAPI app
+│           └── api/                # (planned) FastAPI app — see #67
 │               └── __init__.py
-└── frontend/                       # (planned) Vite + React + TS UI
-    └── README.md
+└── frontend/
+    ├── package.json                # pnpm workspace
+    ├── vite.config.ts
+    ├── public/mockServiceWorker.js # MSW worker (committed)
+    └── src/
+        ├── main.tsx                # MSW + ErrorBoundary + BrowserRouter
+        ├── App.tsx                 # <Routes> for /connect /library /migrate /reports
+        ├── pages/                  # One folder per top-level route
+        ├── components/{layout,ui,library,migrate}/
+        ├── features/{auth,library,migrate,reports}/   # TanStack Query hooks
+        ├── contexts/SelectionContext.tsx              # Cross-page selection
+        ├── hooks/                  # useAutoFocusHeading, useFocusTrap, useMigrationEvents
+        ├── lib/                    # http (timeout-aware), ws, query-client
+        ├── types/api.ts            # Hand-mirrored TS types (will be generated from OpenAPI in #71)
+        └── test/msw/               # Handlers, fixtures, server, browser worker
 ```
 
 ## License

--- a/backend/README.md
+++ b/backend/README.md
@@ -124,8 +124,31 @@ couldn't be found at all on YouTube Music are listed under `not_found`.
 
 The `Migrator` is event-driven: it accepts an `on_event` callback that
 receives typed events (`PlaylistStarted`, `AlbumProcessed`, ...). The CLI
-uses this to print progress; a future FastAPI WebSocket endpoint will use
-the same hook to stream progress to the frontend.
+uses this to print progress; the future FastAPI WebSocket endpoint
+(issue #70) will use the same hook to stream progress to the frontend.
+
+### Error taxonomy in `YTMusicClient`
+
+Public methods of `YTMusicClient` raise one of three types instead of
+returning `None` or swallowing exceptions:
+
+- `YTMusicAuthError` — only on construction, when `_verify_auth` cannot
+  search at all. Means `browser.json` is missing or expired; the user
+  must rerun `setup_ytmusic.py`.
+- `YTMusicTransientError` — network blips, throttling, or partial JSON
+  responses. Already retried with exponential backoff inside the client;
+  if it surfaces, the retry budget is exhausted. Callers may decide to
+  skip the item and continue with the next.
+- `YTMusicFatalError` — auth/quota/4xx persistent failures, or anything
+  the classifier cannot positively identify as transient. The `Migrator`
+  catches it per playlist/album, records the reason in
+  `MigrationReport.error`, and continues.
+
+Why both errors propagate instead of returning `None`: silent fallbacks
+masked failures that wasted the retry budget and showed empty playlists
+in YouTube Music with no explanation. See
+[ytmusic_client.py `_classify_exception`](src/spotify_to_ytmusic/core/ytmusic_client.py)
+for the mapping.
 
 ```
 core/
@@ -171,6 +194,20 @@ Files written there:
   that were misses before).
 
 The whole `data/` directory is gitignored.
+
+## Tests
+
+```bash
+cd backend
+pip install -e ".[dev]"
+pytest
+```
+
+The suite under `backend/tests/` covers `Migrator` and `YTMusicClient`
+(error classification, retry/backoff, fatal propagation). It is **not
+yet exhaustive** — issue #66 tracks the gap (Spotify payload shapes,
+TrackCache atomicity, fixture-based regression tests for every gotcha
+in `CLAUDE.md`). When in doubt, write a test before the fix.
 
 ## Limitations
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,13 +1,19 @@
 # Frontend
 
-Interfaz web para `spotify-to-ytmusic`. Se comunica con el backend FastAPI en `../backend` via HTTP + WebSockets.
+Interfaz web para `spotify-to-ytmusic`. Habla con el backend (cuando
+exista, ver issues #67–#71) vía HTTP + WebSocket bajo el prefijo
+`/api`. Mientras tanto, **todas las llamadas las sirve MSW**.
 
-## Stack recomendado
+## Stack
 
-- **Vite** + **React** + **TypeScript**
-- **TailwindCSS** para estilos
-- **TanStack Query** para estado HTTP
-- WebSocket nativo para progreso en vivo de migraciones
+- **Vite 8** + **React 19** + **TypeScript**
+- **react-router-dom 7** (rutas reales: `/connect`, `/library`,
+  `/migrate`, `/reports`, `/reports/:id`)
+- **TanStack Query 5** para estado HTTP
+- **TailwindCSS 3** para estilos
+- **MSW 2** para mockear el backend mientras no exista
+- **Vitest** + **Testing Library** para tests
+- WebSocket nativo con reconexión exponencial
 
 ## Inicio rápido
 
@@ -16,81 +22,144 @@ pnpm install
 pnpm dev
 ```
 
-Abre http://localhost:5173 en tu navegador.
+Abre http://localhost:5173. La app arranca el worker MSW y todo el
+tráfico `*/api/*` lo intercepta — verás la UI completamente funcional
+contra fixtures.
+
+> **Importante:** usa `pnpm`, no `npm`. `pnpm-lock.yaml` es la fuente
+> de verdad. Algunos paquetes (`msw`) provocan crashes en npm 11.x.
 
 ## Scripts
 
 | Script | Propósito |
 | ------ | -------- |
 | `pnpm dev` | Servidor de desarrollo con HMR |
-| `pnpm build` | Build de producción |
-| `pnpm lint` | Lint con ESLint |
-| `pnpm format` | Format con Prettier |
-| `pnpm format:check` | Verifica formato sin modificar |
-| `pnpm test` | Tests en modo watch |
-| `pnpm test:run` | Tests una vez |
+| `pnpm build` | `tsc -b && vite build` |
+| `pnpm lint` | ESLint |
+| `pnpm format` / `format:check` | Prettier |
+| `pnpm test` | Vitest en watch mode |
+| `pnpm test:run` | Vitest una pasada (lo que corre CI) |
 
-## Mocks (MSW)
+## Arquitectura
 
-El proyecto usa **MSW** para mockear el backend durante desarrollo. Los mocks están en `src/test/msw/`.
-
-### Cómo funcionan
-
-En `src/main.tsx`, `enableMocking()` inicia el Service Worker solo en entorno de desarrollo:
-
-```tsx
-async function enableMocking() {
-  if (!import.meta.env.DEV) return
-  const { worker } = await import('@/test/msw/browser')
-  await worker.start({ onUnhandledRequest: 'bypass' })
-}
+```
+src/
+├── main.tsx              # MSW + ErrorBoundary + BrowserRouter + QueryClient
+├── App.tsx               # <Routes> dentro de <SelectionProvider>
+├── pages/                # Una carpeta por ruta top-level
+│   ├── Connect/          # Spotify + YT Music
+│   ├── Library/          # Tabs Playlists/Albums + selección
+│   ├── Migrate/          # Confirmación + EventLog en vivo
+│   └── Reports/          # List + Detail con deep-link a /reports/:id
+├── components/
+│   ├── layout/           # AppShell, Header (NavLink), Footer, ErrorBoundary, ConnectionStatus
+│   ├── ui/               # Button, Toast, Card, Input, Skeleton, Spinner, FieldError, …
+│   ├── library/          # Tabs, SelectionSummary
+│   └── migrate/          # PlaylistProgress, AlbumProgress, NotFound, CompletionSummary, ConnectionBanner
+├── features/             # TanStack Query hooks por dominio
+│   ├── auth/             # useSpotifyAuth, useYTMusicAuth, useHealth
+│   ├── library/          # usePlaylists, useAlbums, useSelection (delega en SelectionContext)
+│   ├── migrate/          # useStartMigration, useMigrationSelection, derivaciones del log
+│   └── reports/          # useReports, useReport
+├── contexts/             # SelectionContext (lookup de selección entre páginas)
+├── hooks/
+│   ├── useMigrationEvents.ts    # WS + reducer incremental
+│   ├── useAutoFocusHeading.ts   # Focus management por página (a11y)
+│   └── useFocusTrap.ts          # Trap para diálogos (Reports/Detail)
+├── lib/
+│   ├── http.ts           # fetch wrapper con AbortSignal.timeout (15s default)
+│   ├── ws.ts             # WsConnection con backoff y short-circuit en cierres limpios
+│   ├── query-client.ts   # TanStack Query client
+│   ├── download.ts       # Descarga blob → JSON
+│   └── ToastContext.tsx
+├── types/api.ts          # Espejo manual de los modelos del backend (será generado desde OpenAPI en #71)
+└── test/
+    ├── setup.ts          # Vitest + MSW lifecycle
+    └── msw/              # handlers, fixtures, server (Node), browser (worker)
 ```
 
-### Desactivar mocks
+### Patrones que NO hay que romper
 
-Cuando el backend FastAPI esté disponible, comenta o elimina la llamada a `enableMocking()` en `src/main.tsx`:
+- **La selección vive en `SelectionContext`**, no en `useState` por
+  página. `useSelection` (en `features/library/`) delega ahí: si añades
+  una página que necesite leer la selección, lee del context, no
+  reintroduzcas estado local.
+- **Las rutas se navegan con `<NavLink>` / `<Link>` / `useNavigate`**.
+  No vuelvas a un enum `section`.
+- **Cada página gestiona su propio focus** con `useAutoFocusHeading`.
+  No hagas un `useEffect` global en `App.tsx`.
+- **Las llamadas HTTP pasan por `lib/http.ts`** para heredar el timeout
+  de 15 s. No llames a `fetch` directamente desde features.
+- **El WS reconecta solo en cierres anormales.** `WsConnection.onclose`
+  trata `wasClean || code === 1000 || code === 1005` como cierre final.
+  Si añades streams nuevos, asegúrate de que el servidor cierra con
+  `1000` cuando termina (MSW lo hace ya, FastAPI tendrá que hacerlo
+  también — ver #70).
 
-```tsx
-// Desactivar cuando haya backend real:
-// enableMocking().then(() => { ... })
+### Mocks (MSW)
 
-// Mientras tanto:
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
-  </StrictMode>
-)
+Hoy la app entera corre contra MSW. Los handlers están en
+[`src/test/msw/handlers.ts`](src/test/msw/handlers.ts) y las fixtures en
+[`src/test/msw/fixtures.ts`](src/test/msw/fixtures.ts).
+
+Los patrones de ruta **deben empezar con `*/api/...`**, no `/api/...`.
+Las rutas relativas no matchean en el entorno Node de Vitest (sí en el
+worker del navegador), y los tests fallan silenciosamente con
+`onUnhandledRequest: 'error'`.
+
+```ts
+// ✅ Match en navegador y en Node (Vitest)
+http.get('*/api/playlists', () => HttpResponse.json([...]))
+
+// ❌ Solo match en navegador
+http.get('/api/playlists', () => HttpResponse.json([...]))
 ```
 
-### Cambiar el endpoint
+### Conmutar a backend real
 
-Edita los handlers en `src/test/msw/handlers.ts` para apuntar al backend real cuando lo necesites.
+Cuando el FastAPI exista (issues #67–#70 + proxy en #71):
 
-## Tests
+1. `vite.config.ts` ganará un `server.proxy` apuntando `/api` al puerto
+   del backend.
+2. `main.tsx` arrancará MSW solo si `VITE_USE_MSW=true`. Sin esa flag,
+   las peticiones se irán al backend a través del proxy.
 
-Ejecuta con:
-
-```bash
-pnpm test        # watch mode
-pnpm test:run    # una vez
-```
-
-Los tests usan **Vitest** + **Testing Library**. Ver `src/test/setup.ts` para la configuración.
+Hasta entonces, MSW siempre está ON en desarrollo y hay que vivir con
+los fixtures.
 
 ## Contrato con el backend
 
-| Method | Path | Propósito |
-| ------ | ---- | -------- |
-| `GET` | `/api/health` | Liveness probe |
-| `POST` | `/api/auth/spotify` | Trigger Spotify OAuth |
-| `POST` | `/api/auth/ytmusic` | Submit browser headers |
-| `GET` | `/api/playlists` | List playlists de Spotify |
-| `GET` | `/api/albums` | List albums guardados |
-| `POST` | `/api/migrate` | Iniciar migración |
-| `WS` | `/api/migrate/{job_id}/events` | Stream de eventos |
-| `GET` | `/api/reports` | List reportes |
-| `GET` | `/api/reports/{id}` | Ver reporte |
+| Method | Path | Quién lo consume |
+| ------ | ---- | ---------------- |
+| `GET` | `/api/health` | `useHealth` (badge en header) |
+| `POST` | `/api/auth/spotify` | `useSpotifyAuth` → redirige a `accounts.spotify.com` |
+| `POST` | `/api/auth/ytmusic` | `useYTMusicAuth` (envía headers pegados) |
+| `GET` | `/api/playlists` | `usePlaylists` |
+| `GET` | `/api/albums` | `useAlbums` |
+| `POST` | `/api/migrate` | `useStartMigration` (devuelve `{ jobId }`) |
+| `WS` | `/api/migrate/{jobId}/events` | `useMigrationEvents` (eventos tipados → reducer) |
+| `GET` | `/api/reports` | `useReports` |
+| `GET` | `/api/reports/:id` | `useReport` |
 
-El backend emite eventos tipados via `on_event` callback — el endpoint WebSocket los reenvía como JSON.
+Los tipos espejo del backend están en [`src/types/api.ts`](src/types/api.ts).
+La generación automática desde `/openapi.json` la cubre la issue #71.
+
+## Tests
+
+```bash
+pnpm test:run
+```
+
+258+ tests en este momento (suite completa frontend). Los tests de hooks
+con WebSocket usan un mock `MockWebSocket` definido en cada archivo —
+mira `useMigrationEvents.test.tsx` como referencia.
+
+## Accesibilidad
+
+- Skip-link "Ir al contenido principal" en `AppShell`.
+- `<main role="main">` con focus trap manejado por hooks dedicados.
+- `aria-current="page"` en navegación, `aria-live="polite"` en el log
+  de eventos, `role="tablist"` en Library con keyboard navigation
+  (←/→ entre tabs).
+- `ConnectionBadge` distingue estados con icono + color (no solo color)
+  para cumplir WCAG 1.4.1.


### PR DESCRIPTION
## Summary

- Reframe `CLAUDE.md`: frontend already exists end-to-end against MSW;
  the FastAPI integration (#67–#71) is the next big block, not the
  frontend. New gotchas codify the invariants we just landed (WS clean
  close, `SelectionContext`, router, per-page focus, `http` timeout,
  YT Music error taxonomy). Adds a "Roadmap state" section pointing
  at the open backlog and the critical path (#67 → #71).
- `README.md`: stop calling the frontend "planned". New Status section
  separating what works in CLI vs MSW vs what is missing.
- `backend/README.md`: documents `YTMusicAuthError` /
  `YTMusicTransientError` / `YTMusicFatalError` and why public methods
  raise instead of returning `None`. Adds a Tests section.
- `frontend/README.md`: full rewrite — real stack, real layout, list of
  patterns NOT to break (selection, routing, focus, `http`, `ws`), MSW
  path-pattern caveat, contract table, a11y notes.
- `.claude/commands/resolve-issue.md`: adds a "verify repo reality"
  step before planning so we don't redo work; expands the test step to
  cover lint/format:check/build (matches CI); heredoc commit template;
  PR body template with real Test plan checklist; new "When to
  escalate" guidance; "Anti-patterns we've hit" section with six
  concrete traps from this project (silent `except Exception` in
  `ytmusic_client`, page-local `useState(new Set())` for selection,
  global focus side-effect, reconnect on clean WS close, direct
  `fetch`, planning files nobody asked for).

## Closes

Docs only — no issue to close.

## Test plan

- [ ] Read through `CLAUDE.md` end-to-end and confirm it matches the
      current state of the repo (no "planned" language for things that
      already shipped).
- [ ] Read `frontend/README.md` and confirm the contract table and the
      "patterns NOT to break" list match the code in `src/`.
- [ ] Sanity-check `backend/README.md` Architecture section against
      `core/ytmusic_client.py` (error class names, classifier behavior).
- [ ] Skim `.claude/commands/resolve-issue.md` and confirm the steps
      reflect our current workflow (gh CLI, Conventional Commits with
      scope, no AI co-authorship, `pnpm test:run` / `pytest`).