### PR TITLE
feat(backend): failure events, atomic reports, and expanded test suite (#64-#66)

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,28 @@
+name: Backend Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'backend/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'backend/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: pip install -e '.[dev]'
+      - name: Run pytest
+        run: pytest -v

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,3 +30,6 @@ spotify-to-ytmusic = "spotify_to_ytmusic.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/backend/src/spotify_to_ytmusic/cli/__init__.py
+++ b/backend/src/spotify_to_ytmusic/cli/__init__.py
@@ -14,8 +14,11 @@ from spotify_to_ytmusic.core.config import (
 )
 from spotify_to_ytmusic.core.events import (
     AlbumProcessed,
+    AlbumSaveFailed,
     AlbumsDiscovered,
     MigrationEvent,
+    PlaylistChunkFailed,
+    PlaylistCreationFailed,
     PlaylistFinished,
     PlaylistStarted,
     PlaylistsDiscovered,
@@ -46,6 +49,15 @@ def _print_event(event: MigrationEvent) -> None:
         print(f"Found {event.count} saved albums\n")
     elif isinstance(event, AlbumProcessed):
         print(f"[album] {event.label}\n  {event.status}")
+    elif isinstance(event, PlaylistCreationFailed):
+        print(f"  [error] No se pudo crear la playlist '{event.name}': {event.reason}")
+    elif isinstance(event, PlaylistChunkFailed):
+        print(
+            f"  [error] Chunk {event.chunk_index + 1}/{event.total_chunks} "
+            f"fallo en '{event.name}': {event.reason}"
+        )
+    elif isinstance(event, AlbumSaveFailed):
+        print(f"  [error] No se pudo guardar el album '{event.label}': {event.reason}")
 
 
 def _select_playlists(summaries: list[PlaylistSummary]) -> list[str] | None:

--- a/backend/src/spotify_to_ytmusic/core/events.py
+++ b/backend/src/spotify_to_ytmusic/core/events.py
@@ -33,12 +33,35 @@ class AlbumProcessed:
     status: str  # "saved" | "found (not saved)" | "not found"
 
 
+@dataclass
+class PlaylistCreationFailed:
+    name: str
+    reason: str
+
+
+@dataclass
+class PlaylistChunkFailed:
+    name: str
+    chunk_index: int
+    total_chunks: int
+    reason: str
+
+
+@dataclass
+class AlbumSaveFailed:
+    label: str
+    reason: str
+
+
 MigrationEvent = Union[
     PlaylistsDiscovered,
     PlaylistStarted,
     PlaylistFinished,
     AlbumsDiscovered,
     AlbumProcessed,
+    PlaylistCreationFailed,
+    PlaylistChunkFailed,
+    AlbumSaveFailed,
 ]
 
 EventCallback = Callable[[MigrationEvent], None]

--- a/backend/src/spotify_to_ytmusic/core/migrator.py
+++ b/backend/src/spotify_to_ytmusic/core/migrator.py
@@ -5,8 +5,11 @@ from pathlib import Path
 from spotify_to_ytmusic.core.config import TRACK_CACHE_FILE, YTMUSIC_SEARCH_DELAY_S
 from spotify_to_ytmusic.core.events import (
     AlbumProcessed,
+    AlbumSaveFailed,
     AlbumsDiscovered,
     EventCallback,
+    PlaylistChunkFailed,
+    PlaylistCreationFailed,
     PlaylistFinished,
     PlaylistStarted,
     PlaylistsDiscovered,
@@ -23,6 +26,7 @@ from spotify_to_ytmusic.core.models import (
 from spotify_to_ytmusic.core.spotify_client import SpotifyClient
 from spotify_to_ytmusic.core.track_cache import TrackCache
 from spotify_to_ytmusic.core.ytmusic_client import (
+    YTMusicChunkError,
     YTMusicClient,
     YTMusicFatalError,
     YTMusicTransientError,
@@ -80,15 +84,26 @@ class Migrator:
         yt_playlist_id: str | None = None
         error_message: str | None = None
         try:
-            yt_playlist_id = self.ytmusic.create_playlist(
-                playlist.name, playlist.description, video_ids
+            yt_playlist_id = self.ytmusic.create_playlist(playlist.name, playlist.description)
+            self.ytmusic.add_tracks_to_playlist(yt_playlist_id, video_ids)
+        except YTMusicChunkError as exc:
+            error_message = f"chunk {exc.chunk_index}/{exc.total_chunks} failed: {exc.reason}"
+            self.on_event(
+                PlaylistChunkFailed(
+                    name=playlist.name,
+                    chunk_index=exc.chunk_index,
+                    total_chunks=exc.total_chunks,
+                    reason=exc.reason,
+                )
             )
         except YTMusicFatalError as exc:
-            # Per-playlist abort: record the error and move on so a single
-            # broken playlist does not kill the whole job.
             error_message = str(exc)
+            if yt_playlist_id is None:
+                self.on_event(PlaylistCreationFailed(name=playlist.name, reason=error_message))
         except YTMusicTransientError as exc:
             error_message = f"transient (max retries exceeded): {exc}"
+            if yt_playlist_id is None:
+                self.on_event(PlaylistCreationFailed(name=playlist.name, reason=error_message))
 
         finished_found = len(video_ids) if error_message is None else 0
         self.report.playlists.append(
@@ -157,8 +172,10 @@ class Migrator:
             saved = self.ytmusic.save_album(match["browseId"])
         except YTMusicFatalError as exc:
             error_message = str(exc)
+            self.on_event(AlbumSaveFailed(label=album.label, reason=error_message))
         except YTMusicTransientError as exc:
             error_message = f"transient (max retries exceeded): {exc}"
+            self.on_event(AlbumSaveFailed(label=album.label, reason=error_message))
 
         status = "saved" if saved else "found (not saved)"
         self.report.albums.append(

--- a/backend/src/spotify_to_ytmusic/core/report.py
+++ b/backend/src/spotify_to_ytmusic/core/report.py
@@ -1,5 +1,6 @@
 """Persists MigrationReport instances to disk as JSON."""
 import json
+import os
 from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
@@ -13,11 +14,17 @@ def save_report(report: MigrationReport, directory: Path | str | None = None) ->
     target_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     path = target_dir / f"migration_report_{timestamp}.json"
+
+    for orphan in target_dir.glob("migration_report_*.tmp"):
+        orphan.unlink(missing_ok=True)
+
     payload = {
         "playlists": [asdict(p) for p in report.playlists],
         "albums": [asdict(a) for a in report.albums],
         "not_found": [asdict(n) for n in report.not_found],
     }
-    with open(path, "w", encoding="utf-8") as f:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2, ensure_ascii=False)
+    os.replace(tmp, path)
     return path

--- a/backend/src/spotify_to_ytmusic/core/ytmusic_client.py
+++ b/backend/src/spotify_to_ytmusic/core/ytmusic_client.py
@@ -59,6 +59,16 @@ def _classify_exception(exc: BaseException) -> type:
     return YTMusicFatalError
 
 
+class YTMusicChunkError(YTMusicTransientError):
+    """A chunk of tracks failed to be added after all retries. Carries chunk metadata."""
+
+    def __init__(self, chunk_index: int, total_chunks: int, reason: str):
+        self.chunk_index = chunk_index
+        self.total_chunks = total_chunks
+        self.reason = reason
+        super().__init__(reason)
+
+
 class YTMusicClient:
     def __init__(self, auth_file: str = BROWSER_AUTH_FILE):
         self.yt = YTMusic(auth_file)
@@ -155,9 +165,7 @@ class YTMusicClient:
     def _find_first_with_id(results: list[dict], id_field: str) -> Optional[dict]:
         return next((r for r in results if r.get(id_field)), None)
 
-    def create_playlist(
-        self, name: str, description: str, video_ids: list[str]
-    ) -> str:
+    def create_playlist(self, name: str, description: str) -> str:
         try:
             playlist_id = self.yt.create_playlist(name, description)
         except Exception as exc:
@@ -166,16 +174,24 @@ class YTMusicClient:
                 f"{type(exc).__name__}: {exc}"
             ) from exc
         if not playlist_id or not isinstance(playlist_id, str):
-            # Some ytmusicapi failure modes return a status dict instead of an
-            # id. Treat that as fatal: there is nothing to add tracks to.
             raise YTMusicFatalError(
                 f"create_playlist returned invalid id for {name!r}: "
                 f"{playlist_id!r}"
             )
-        for chunk in self._chunked(video_ids, YTMUSIC_PLAYLIST_CHUNK_SIZE):
-            self._add_chunk_with_retry(playlist_id, chunk)
-            time.sleep(YTMUSIC_PLAYLIST_CHUNK_DELAY_S)
         return playlist_id
+
+    def add_tracks_to_playlist(self, playlist_id: str, video_ids: list[str]) -> None:
+        chunks = list(self._chunked(video_ids, YTMUSIC_PLAYLIST_CHUNK_SIZE))
+        for i, chunk in enumerate(chunks):
+            try:
+                self._add_chunk_with_retry(playlist_id, chunk)
+            except YTMusicTransientError as exc:
+                raise YTMusicChunkError(
+                    chunk_index=i,
+                    total_chunks=len(chunks),
+                    reason=str(exc),
+                ) from exc
+            time.sleep(YTMUSIC_PLAYLIST_CHUNK_DELAY_S)
 
     def _add_chunk_with_retry(self, playlist_id: str, chunk: list[str]) -> None:
         # YT Music throttles add_playlist_items intermittently and the response

--- a/backend/tests/fixtures/current_user_playlists.json
+++ b/backend/tests/fixtures/current_user_playlists.json
@@ -1,0 +1,35 @@
+{
+  "items": [
+    {
+      "id": "pl_001",
+      "name": "Discover Weekly",
+      "description": "Your weekly mixtape",
+      "owner": { "id": "user_123" },
+      "items": { "total": 30 },
+      "collaborative": false,
+      "public": false
+    },
+    {
+      "id": "pl_002",
+      "name": "Liked Songs",
+      "description": "",
+      "owner": { "id": "user_123" },
+      "items": { "total": 500 },
+      "collaborative": false,
+      "public": false
+    },
+    {
+      "id": "pl_003",
+      "name": "Collab Mix",
+      "description": "Shared playlist",
+      "owner": { "id": "other_user" },
+      "items": { "total": 45 },
+      "collaborative": true,
+      "public": false
+    }
+  ],
+  "next": null,
+  "total": 3,
+  "limit": 50,
+  "offset": 0
+}

--- a/backend/tests/fixtures/current_user_saved_albums.json
+++ b/backend/tests/fixtures/current_user_saved_albums.json
@@ -1,0 +1,28 @@
+{
+  "items": [
+    {
+      "added_at": "2025-01-01T00:00:00Z",
+      "album": {
+        "id": "album_001",
+        "name": "In Rainbows",
+        "artists": [{ "name": "Radiohead" }],
+        "album_type": "album",
+        "total_tracks": 10
+      }
+    },
+    {
+      "added_at": "2025-01-02T00:00:00Z",
+      "album": {
+        "id": "album_002",
+        "name": "Currents",
+        "artists": [{ "name": "Tame Impala" }],
+        "album_type": "album",
+        "total_tracks": 13
+      }
+    }
+  ],
+  "next": null,
+  "total": 2,
+  "limit": 20,
+  "offset": 0
+}

--- a/backend/tests/fixtures/playlist_tracks_legacy.json
+++ b/backend/tests/fixtures/playlist_tracks_legacy.json
@@ -1,0 +1,22 @@
+{
+  "items": [
+    {
+      "track": {
+        "id": "track_101",
+        "name": "Hotel California",
+        "artists": [{ "name": "Eagles" }],
+        "album": { "name": "Hotel California" },
+        "duration_ms": 391376
+      },
+      "added_at": "2024-01-01T00:00:00Z"
+    },
+    {
+      "track": null,
+      "added_at": "2024-01-02T00:00:00Z"
+    }
+  ],
+  "next": null,
+  "total": 2,
+  "limit": 100,
+  "offset": 0
+}

--- a/backend/tests/fixtures/playlist_tracks_new.json
+++ b/backend/tests/fixtures/playlist_tracks_new.json
@@ -1,0 +1,35 @@
+{
+  "items": [
+    {
+      "item": {
+        "id": "track_001",
+        "name": "Bohemian Rhapsody",
+        "artists": [{ "name": "Queen" }],
+        "album": { "name": "A Night at the Opera" },
+        "duration_ms": 354947
+      },
+      "track": true,
+      "added_at": "2025-01-01T00:00:00Z"
+    },
+    {
+      "item": {
+        "id": "track_002",
+        "name": "Stairway to Heaven",
+        "artists": [{ "name": "Led Zeppelin" }],
+        "album": { "name": "Led Zeppelin IV" },
+        "duration_ms": 482830
+      },
+      "track": true,
+      "added_at": "2025-01-02T00:00:00Z"
+    },
+    {
+      "item": null,
+      "track": false,
+      "added_at": "2025-01-03T00:00:00Z"
+    }
+  ],
+  "next": null,
+  "total": 3,
+  "limit": 100,
+  "offset": 0
+}

--- a/backend/tests/test_migrator.py
+++ b/backend/tests/test_migrator.py
@@ -12,6 +12,7 @@ from spotify_to_ytmusic.core.models import (
 )
 from spotify_to_ytmusic.core.track_cache import TrackCache
 from spotify_to_ytmusic.core.ytmusic_client import (
+    YTMusicChunkError,
     YTMusicFatalError,
     YTMusicTransientError,
 )
@@ -62,6 +63,7 @@ def test_migrate_playlist_records_fatal_in_report_and_continues(tmp_path):
         YTMusicFatalError("creation forbidden"),
         "PL_yt_2",
     ]
+    ytmusic.add_tracks_to_playlist.return_value = None
 
     migrator.migrate_playlists()
 
@@ -170,3 +172,77 @@ def test_migrate_album_records_fatal_from_search_in_report_and_continues(tmp_pat
     ok = migrator.report.albums[1]
     assert ok.error is None
     assert ok.status == "saved"
+
+
+# --- Failure events ------------------------------------------------------
+
+
+def test_migrate_playlist_emits_creation_failed_event(tmp_path):
+    events: list = []
+    spotify = MagicMock()
+    ytmusic = MagicMock()
+    cache = TrackCache(tmp_path / "cache.json")
+    migrator = Migrator(spotify=spotify, ytmusic=ytmusic, cache=cache, on_event=events.append)
+
+    spotify.get_current_user_id.return_value = "u"
+    spotify.list_playlist_summaries.return_value = [_summary("p1", "Broken")]
+    spotify.load_playlist_by_id.return_value = Playlist(
+        id="p1", name="Broken", description="d", tracks=[_track("S", spot_id="t1")]
+    )
+    ytmusic.search_song.return_value = "VID_X"
+    ytmusic.create_playlist.side_effect = YTMusicFatalError("quota exceeded")
+
+    migrator.migrate_playlists()
+
+    creation_failed = [e for e in events if type(e).__name__ == "PlaylistCreationFailed"]
+    assert len(creation_failed) == 1
+    assert creation_failed[0].name == "Broken"
+    assert "quota exceeded" in creation_failed[0].reason
+
+
+def test_migrate_playlist_emits_chunk_failed_event(tmp_path):
+    events: list = []
+    spotify = MagicMock()
+    ytmusic = MagicMock()
+    cache = TrackCache(tmp_path / "cache.json")
+    migrator = Migrator(spotify=spotify, ytmusic=ytmusic, cache=cache, on_event=events.append)
+
+    spotify.get_current_user_id.return_value = "u"
+    spotify.list_playlist_summaries.return_value = [_summary("p1", "ChunkFail")]
+    spotify.load_playlist_by_id.return_value = Playlist(
+        id="p1", name="ChunkFail", description="d", tracks=[_track("S", spot_id="t1")]
+    )
+    ytmusic.search_song.return_value = "VID_X"
+    ytmusic.create_playlist.return_value = "PL_created"
+    ytmusic.add_tracks_to_playlist.side_effect = YTMusicChunkError(
+        chunk_index=0, total_chunks=1, reason="throttled"
+    )
+
+    migrator.migrate_playlists()
+
+    chunk_failed = [e for e in events if type(e).__name__ == "PlaylistChunkFailed"]
+    assert len(chunk_failed) == 1
+    assert chunk_failed[0].name == "ChunkFail"
+    assert chunk_failed[0].chunk_index == 0
+    assert chunk_failed[0].total_chunks == 1
+
+
+def test_migrate_album_emits_save_failed_event(tmp_path):
+    events: list = []
+    spotify = MagicMock()
+    ytmusic = MagicMock()
+    cache = TrackCache(tmp_path / "cache.json")
+    migrator = Migrator(spotify=spotify, ytmusic=ytmusic, cache=cache, on_event=events.append)
+
+    spotify.get_saved_albums.return_value = [
+        Album(name="In Rainbows", artist="Radiohead", spotify_id="a1"),
+    ]
+    ytmusic.search_album.return_value = {"browseId": "BR"}
+    ytmusic.save_album.side_effect = YTMusicFatalError("save forbidden")
+
+    migrator.migrate_albums()
+
+    save_failed = [e for e in events if type(e).__name__ == "AlbumSaveFailed"]
+    assert len(save_failed) == 1
+    assert save_failed[0].label == "Radiohead - In Rainbows"
+    assert "save forbidden" in save_failed[0].reason

--- a/backend/tests/test_migrator.py
+++ b/backend/tests/test_migrator.py
@@ -246,3 +246,89 @@ def test_migrate_album_emits_save_failed_event(tmp_path):
     assert len(save_failed) == 1
     assert save_failed[0].label == "Radiohead - In Rainbows"
     assert "save forbidden" in save_failed[0].reason
+
+
+# --- Event ordering --------------------------------------------------------
+
+
+def test_migrator_emits_events_in_correct_order(tmp_path):
+    events: list = []
+    spotify = MagicMock()
+    ytmusic = MagicMock()
+    cache = TrackCache(tmp_path / "cache.json")
+    migrator = Migrator(spotify=spotify, ytmusic=ytmusic, cache=cache, on_event=events.append)
+
+    spotify.get_current_user_id.return_value = "u"
+    spotify.list_playlist_summaries.return_value = [_summary("p1", "P1")]
+    spotify.load_playlist_by_id.return_value = Playlist(
+        id="p1", name="P1", description="d", tracks=[_track("S", spot_id="t1")]
+    )
+    ytmusic.search_song.return_value = "VID"
+    ytmusic.create_playlist.return_value = "PL"
+    ytmusic.add_tracks_to_playlist.return_value = None
+
+    spotify.get_saved_albums.return_value = [
+        Album(name="A", artist="B", spotify_id="a1"),
+    ]
+    ytmusic.search_album.return_value = {"browseId": "BR"}
+    ytmusic.save_album.return_value = True
+
+    migrator.migrate_playlists()
+    migrator.migrate_albums()
+
+    event_types = [type(e).__name__ for e in events]
+    assert event_types.index("PlaylistsDiscovered") < event_types.index("PlaylistStarted")
+    assert event_types.index("PlaylistStarted") < event_types.index("PlaylistFinished")
+    assert event_types.index("AlbumsDiscovered") < event_types.index("AlbumProcessed")
+
+
+# --- Cache hits ------------------------------------------------------------
+
+
+def test_migrator_uses_cache_hit_skips_search(tmp_path):
+    events: list = []
+    spotify = MagicMock()
+    ytmusic = MagicMock()
+    cache = TrackCache(tmp_path / "cache.json")
+    cache.set_hit("t1", "CACHED_VID")
+    migrator = Migrator(spotify=spotify, ytmusic=ytmusic, cache=cache, on_event=events.append)
+
+    spotify.get_current_user_id.return_value = "u"
+    spotify.list_playlist_summaries.return_value = [_summary("p1", "P1")]
+    spotify.load_playlist_by_id.return_value = Playlist(
+        id="p1", name="P1", description="d", tracks=[_track("S", spot_id="t1")]
+    )
+    ytmusic.create_playlist.return_value = "PL"
+    ytmusic.add_tracks_to_playlist.return_value = None
+
+    migrator.migrate_playlists()
+
+    ytmusic.search_song.assert_not_called()
+    [finished] = [e for e in events if type(e).__name__ == "PlaylistFinished"]
+    assert finished.found == 1
+
+
+# --- Empty spotify_id bypasses cache ---------------------------------------
+
+
+def test_migrator_handles_empty_spotify_id(tmp_path):
+    events: list = []
+    spotify = MagicMock()
+    ytmusic = MagicMock()
+    cache = TrackCache(tmp_path / "cache.json")
+    migrator = Migrator(spotify=spotify, ytmusic=ytmusic, cache=cache, on_event=events.append)
+
+    spotify.get_current_user_id.return_value = "u"
+    spotify.list_playlist_summaries.return_value = [_summary("p1", "P1")]
+    spotify.load_playlist_by_id.return_value = Playlist(
+        id="p1", name="P1", description="d", tracks=[_track("Local File", spot_id="")]
+    )
+    ytmusic.search_song.return_value = "VID_LOCAL"
+    ytmusic.create_playlist.return_value = "PL"
+    ytmusic.add_tracks_to_playlist.return_value = None
+
+    migrator.migrate_playlists()
+
+    ytmusic.search_song.assert_called_once()
+    [finished] = [e for e in events if type(e).__name__ == "PlaylistFinished"]
+    assert finished.found == 1

--- a/backend/tests/test_report.py
+++ b/backend/tests/test_report.py
@@ -1,0 +1,53 @@
+"""Tests for atomic report writes."""
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from spotify_to_ytmusic.core.models import MigrationReport
+from spotify_to_ytmusic.core.report import save_report
+
+
+def _empty_report() -> MigrationReport:
+    return MigrationReport()
+
+
+def test_save_report_writes_valid_json(tmp_path: Path):
+    report = _empty_report()
+    path = save_report(report, directory=tmp_path)
+
+    assert path.exists()
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    assert "playlists" in data
+    assert "albums" in data
+    assert "not_found" in data
+
+
+def test_save_report_no_residual_tmp(tmp_path: Path):
+    report = _empty_report()
+    save_report(report, directory=tmp_path)
+
+    tmp_files = list(tmp_path.glob("*.tmp"))
+    assert tmp_files == []
+
+
+def test_save_report_interrupted_does_not_corrupt(tmp_path: Path):
+    report = _empty_report()
+    with patch("spotify_to_ytmusic.core.report.json.dump", side_effect=RuntimeError("boom")):
+        with pytest.raises(RuntimeError, match="boom"):
+            save_report(report, directory=tmp_path)
+
+    json_files = list(tmp_path.glob("*.json"))
+    assert json_files == []
+
+
+def test_save_report_cleans_orphan_tmp(tmp_path: Path):
+    orphan = tmp_path / "migration_report_20250101_000000.json.tmp"
+    orphan.write_text("garbage")
+
+    report = _empty_report()
+    save_report(report, directory=tmp_path)
+
+    assert not orphan.exists()

--- a/backend/tests/test_spotify_client.py
+++ b/backend/tests/test_spotify_client.py
@@ -1,0 +1,170 @@
+"""Tests for SpotifyClient: payload shapes, pagination, 403 handling."""
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from spotipy.exceptions import SpotifyException
+
+from spotify_to_ytmusic.core.models import PlaylistSummary
+from spotify_to_ytmusic.core.spotify_client import SpotifyClient
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load_fixture(name: str) -> dict:
+    with open(FIXTURES / name, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _make_client(mock_sp: MagicMock) -> SpotifyClient:
+    client = object.__new__(SpotifyClient)
+    client.sp = mock_sp
+    return client
+
+
+# --- list_playlist_summaries -----------------------------------------------
+
+
+def test_list_playlist_summaries_uses_items_total():
+    sp = MagicMock()
+    sp.current_user_playlists.return_value = _load_fixture("current_user_playlists.json")
+    client = _make_client(sp)
+
+    summaries = client.list_playlist_summaries("user_123")
+
+    assert len(summaries) == 3
+    assert summaries[0] == PlaylistSummary(
+        id="pl_001",
+        name="Discover Weekly",
+        description="Your weekly mixtape",
+        track_count=30,
+        owner_id="user_123",
+        is_own=True,
+    )
+    assert summaries[2].is_own is False
+
+
+def test_list_playlist_summaries_skips_none_items():
+    sp = MagicMock()
+    sp.current_user_playlists.return_value = {
+        "items": [None, {"id": "p1", "name": "OK", "description": "", "owner": {"id": "u"}, "items": {"total": 1}}],
+        "next": None,
+    }
+    client = _make_client(sp)
+
+    summaries = client.list_playlist_summaries("u")
+    assert len(summaries) == 1
+    assert summaries[0].id == "p1"
+
+
+# --- _build_track (new payload: item.item) --------------------------------
+
+
+def test_build_track_new_payload():
+    fixture = _load_fixture("playlist_tracks_new.json")
+    track_item = fixture["items"][0]
+
+    track = SpotifyClient._build_track(track_item)
+
+    assert track is not None
+    assert track.name == "Bohemian Rhapsody"
+    assert track.artist == "Queen"
+    assert track.album == "A Night at the Opera"
+    assert track.duration_ms == 354947
+    assert track.spotify_id == "track_001"
+
+
+def test_build_track_new_payload_returns_none_for_null_item():
+    fixture = _load_fixture("playlist_tracks_new.json")
+    track_item = fixture["items"][2]
+
+    assert SpotifyClient._build_track(track_item) is None
+
+
+# --- _build_track (legacy payload: item.track) ----------------------------
+
+
+def test_build_track_legacy_payload():
+    fixture = _load_fixture("playlist_tracks_legacy.json")
+    track_item = fixture["items"][0]
+
+    track = SpotifyClient._build_track(track_item)
+
+    assert track is not None
+    assert track.name == "Hotel California"
+    assert track.artist == "Eagles"
+    assert track.spotify_id == "track_101"
+
+
+def test_build_track_legacy_returns_none_for_null_track():
+    fixture = _load_fixture("playlist_tracks_legacy.json")
+    track_item = fixture["items"][1]
+
+    assert SpotifyClient._build_track(track_item) is None
+
+
+# --- _get_playlist_tracks pagination --------------------------------------
+
+
+def test_get_playlist_tracks_paginates():
+    sp = MagicMock()
+    page1 = {
+        "items": [{"item": {"id": "t1", "name": "A", "artists": [{"name": "B"}], "album": {"name": "C"}, "duration_ms": 100}}],
+        "next": "https://api.spotify.com/v1/playlists/p1/tracks?offset=1",
+    }
+    page2 = {
+        "items": [{"item": {"id": "t2", "name": "D", "artists": [{"name": "E"}], "album": {"name": "F"}, "duration_ms": 200}}],
+        "next": None,
+    }
+    sp.playlist_tracks.return_value = page1
+    sp.next.side_effect = [page2]
+
+    client = _make_client(sp)
+    tracks = client._get_playlist_tracks("p1")
+
+    assert len(tracks) == 2
+    assert tracks[0].spotify_id == "t1"
+    assert tracks[1].spotify_id == "t2"
+    assert sp.playlist_tracks.call_count == 1
+    assert sp.next.call_count == 1
+
+
+# --- load_playlist_by_id 403 → None ---------------------------------------
+
+
+def test_load_playlist_by_id_returns_none_on_403():
+    sp = MagicMock()
+    sp.playlist_tracks.side_effect = SpotifyException(403, -1, "Forbidden")
+
+    client = _make_client(sp)
+    result = client.load_playlist_by_id("p1", "Secret", "desc")
+
+    assert result is None
+
+
+def test_load_playlist_by_id_reraises_non_403():
+    sp = MagicMock()
+    sp.playlist_tracks.side_effect = SpotifyException(500, -1, "Server error")
+
+    client = _make_client(sp)
+
+    with pytest.raises(SpotifyException, match="Server error"):
+        client.load_playlist_by_id("p1", "Broken", "desc")
+
+
+# --- get_saved_albums -----------------------------------------------------
+
+
+def test_get_saved_albums():
+    sp = MagicMock()
+    sp.current_user_saved_albums.return_value = _load_fixture("current_user_saved_albums.json")
+
+    client = _make_client(sp)
+    albums = client.get_saved_albums()
+
+    assert len(albums) == 2
+    assert albums[0].name == "In Rainbows"
+    assert albums[0].artist == "Radiohead"
+    assert albums[0].spotify_id == "album_001"
+    assert albums[1].name == "Currents"

--- a/backend/tests/test_track_cache.py
+++ b/backend/tests/test_track_cache.py
@@ -1,0 +1,124 @@
+"""Tests for TrackCache: round-trip, atomic flush, edge cases."""
+import json
+from pathlib import Path
+
+from spotify_to_ytmusic.core.track_cache import NOT_FOUND_SENTINEL, TrackCache
+
+
+def _cache(tmp_path: Path) -> TrackCache:
+    return TrackCache(tmp_path / "cache.json")
+
+
+# --- Round-trip ------------------------------------------------------------
+
+
+def test_cache_set_hit_and_get(tmp_path: Path):
+    c = _cache(tmp_path)
+    c.set_hit("spot_1", "vid_1")
+    hit, value = c.get("spot_1")
+    assert hit is True
+    assert value == "vid_1"
+
+
+def test_cache_miss_returns_none_value(tmp_path: Path):
+    c = _cache(tmp_path)
+    c.set_miss("spot_2")
+    hit, value = c.get("spot_2")
+    assert hit is True
+    assert value is None
+
+
+def test_cache_unknown_id_returns_miss(tmp_path: Path):
+    c = _cache(tmp_path)
+    hit, value = c.get("unknown")
+    assert hit is False
+    assert value is None
+
+
+# --- Empty / invalid ids ---------------------------------------------------
+
+
+def test_cache_ignores_empty_spotify_id(tmp_path: Path):
+    c = _cache(tmp_path)
+    c.set_hit("", "vid_1")
+    c.set_miss("")
+    hit, _ = c.get("")
+    assert hit is False
+
+
+def test_cache_ignores_empty_video_id(tmp_path: Path):
+    c = _cache(tmp_path)
+    c.set_hit("spot_1", "")
+    hit, _ = c.get("spot_1")
+    assert hit is False
+
+
+# --- Atomic flush ----------------------------------------------------------
+
+
+def test_flush_writes_and_no_tmp_left(tmp_path: Path):
+    c = _cache(tmp_path)
+    c.set_hit("s1", "v1")
+    c.set_miss("s2")
+    c.flush()
+
+    path = tmp_path / "cache.json"
+    assert path.exists()
+    tmp_files = list(tmp_path.glob("*.tmp"))
+    assert tmp_files == []
+
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["s1"] == "v1"
+    assert data["s2"] == NOT_FOUND_SENTINEL
+
+
+def test_flush_creates_parent_dirs(tmp_path: Path):
+    nested = tmp_path / "sub" / "dir"
+    c = TrackCache(nested / "cache.json")
+    c.set_hit("s1", "v1")
+    c.flush()
+    assert (nested / "cache.json").exists()
+
+
+# --- Load from disk --------------------------------------------------------
+
+
+def test_load_from_existing_file(tmp_path: Path):
+    path = tmp_path / "cache.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"s1": "v1", "s2": NOT_FOUND_SENTINEL}, f)
+
+    c = TrackCache(path)
+    hit1, v1 = c.get("s1")
+    hit2, v2 = c.get("s2")
+    assert hit1 is True and v1 == "v1"
+    assert hit2 is True and v2 is None
+
+
+def test_load_ignores_non_string_values(tmp_path: Path):
+    path = tmp_path / "cache.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"s1": "v1", "s2": 123, "s3": None}, f)
+
+    c = TrackCache(path)
+    assert len(c) == 1
+    hit, _ = c.get("s1")
+    assert hit is True
+
+
+def test_load_handles_corrupt_file(tmp_path: Path):
+    path = tmp_path / "cache.json"
+    path.write_text("not json")
+
+    c = TrackCache(path)
+    assert len(c) == 0
+
+
+def test_load_handles_wrong_shape(tmp_path: Path):
+    path = tmp_path / "cache.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(["a", "b"], f)
+
+    c = TrackCache(path)
+    assert len(c) == 0

--- a/backend/tests/test_ytmusic_client.py
+++ b/backend/tests/test_ytmusic_client.py
@@ -117,6 +117,14 @@ def test_add_tracks_recovers_after_one_transient_failure(ytmusic_client):
     assert ytmusic_client.yt.add_playlist_items.call_count == 2
 
 
+def test_add_tracks_passes_duplicates_true(ytmusic_client):
+    ytmusic_client.yt.add_playlist_items.return_value = {"status": "STATUS_SUCCEEDED"}
+    ytmusic_client.add_tracks_to_playlist("PL", ["v1", "v2"])
+    ytmusic_client.yt.add_playlist_items.assert_called_once_with(
+        "PL", ["v1", "v2"], duplicates=True
+    )
+
+
 def test_add_tracks_raises_chunk_error_after_max_retries(ytmusic_client):
     ytmusic_client.yt.add_playlist_items.return_value = None
     with pytest.raises(YTMusicChunkError, match="exhausted retries"):

--- a/backend/tests/test_ytmusic_client.py
+++ b/backend/tests/test_ytmusic_client.py
@@ -6,6 +6,7 @@ import requests
 from ytmusicapi.exceptions import YTMusicServerError, YTMusicUserError
 
 from spotify_to_ytmusic.core.ytmusic_client import (
+    YTMusicChunkError,
     YTMusicFatalError,
     YTMusicTransientError,
     _classify_exception,
@@ -68,42 +69,88 @@ def test_create_playlist_propagates_fatal_when_yt_create_raises_user_error(
 ):
     ytmusic_client.yt.create_playlist.side_effect = YTMusicUserError("forbidden")
     with pytest.raises(YTMusicFatalError, match="Failed to create playlist"):
-        ytmusic_client.create_playlist("My PL", "desc", ["v1"])
+        ytmusic_client.create_playlist("My PL", "desc")
 
 
 def test_create_playlist_propagates_fatal_when_id_is_empty(ytmusic_client):
     ytmusic_client.yt.create_playlist.return_value = ""
     with pytest.raises(YTMusicFatalError, match="invalid id"):
-        ytmusic_client.create_playlist("My PL", "desc", ["v1"])
+        ytmusic_client.create_playlist("My PL", "desc")
 
 
 def test_create_playlist_propagates_fatal_when_id_is_dict(ytmusic_client):
-    # ytmusicapi sometimes returns a status dict instead of an id on failure.
     ytmusic_client.yt.create_playlist.return_value = {"status": "STATUS_FAILED"}
     with pytest.raises(YTMusicFatalError, match="invalid id"):
-        ytmusic_client.create_playlist("My PL", "desc", ["v1"])
+        ytmusic_client.create_playlist("My PL", "desc")
 
 
-def test_create_playlist_succeeds_when_chunk_throws_then_recovers(ytmusic_client):
+def test_create_playlist_returns_id_on_success(ytmusic_client):
     ytmusic_client.yt.create_playlist.return_value = "PL_real"
-    # First add attempt: transient JSONDecodeError. Second: success.
+    pid = ytmusic_client.create_playlist("PL", "d")
+    assert pid == "PL_real"
+
+
+# --- add_tracks_to_playlist ----------------------------------------------
+
+
+def test_add_tracks_succeeds_with_single_chunk(ytmusic_client):
+    ytmusic_client.yt.add_playlist_items.return_value = {"status": "STATUS_SUCCEEDED"}
+    ytmusic_client.add_tracks_to_playlist("PL", ["v1", "v2"])
+    assert ytmusic_client.yt.add_playlist_items.call_count == 1
+
+
+def test_add_tracks_succeeds_with_multiple_chunks(ytmusic_client):
+    ytmusic_client.yt.add_playlist_items.return_value = {"status": "STATUS_SUCCEEDED"}
+    from spotify_to_ytmusic.core.config import YTMUSIC_PLAYLIST_CHUNK_SIZE
+
+    video_ids = ["v" + str(i) for i in range(YTMUSIC_PLAYLIST_CHUNK_SIZE + 1)]
+    ytmusic_client.add_tracks_to_playlist("PL", video_ids)
+    assert ytmusic_client.yt.add_playlist_items.call_count == 2
+
+
+def test_add_tracks_recovers_after_one_transient_failure(ytmusic_client):
     ytmusic_client.yt.add_playlist_items.side_effect = [
         json.JSONDecodeError("Expecting value", "", 0),
         {"status": "STATUS_SUCCEEDED"},
     ]
-    pid = ytmusic_client.create_playlist("PL", "d", ["v1", "v2"])
-    assert pid == "PL_real"
+    ytmusic_client.add_tracks_to_playlist("PL", ["v1"])
     assert ytmusic_client.yt.add_playlist_items.call_count == 2
 
 
-def test_create_playlist_propagates_fatal_from_chunk_immediately(ytmusic_client):
-    """A fatal during add_playlist_items must NOT burn the retry budget."""
-    ytmusic_client.yt.create_playlist.return_value = "PL_real"
+def test_add_tracks_raises_chunk_error_after_max_retries(ytmusic_client):
+    ytmusic_client.yt.add_playlist_items.return_value = None
+    with pytest.raises(YTMusicChunkError, match="exhausted retries"):
+        ytmusic_client.add_tracks_to_playlist("PL", ["v1"])
+    assert ytmusic_client.yt.add_playlist_items.call_count == 5
+
+
+def test_add_tracks_chunk_error_carries_metadata(ytmusic_client):
+    ytmusic_client.yt.add_playlist_items.return_value = None
+    with pytest.raises(YTMusicChunkError) as exc_info:
+        ytmusic_client.add_tracks_to_playlist("PL", ["v1"])
+    assert exc_info.value.chunk_index == 0
+    assert exc_info.value.total_chunks == 1
+
+
+def test_add_tracks_propagates_fatal_from_chunk_immediately(ytmusic_client):
     ytmusic_client.yt.add_playlist_items.side_effect = YTMusicUserError("forbidden")
     with pytest.raises(YTMusicFatalError, match="Failed to add chunk"):
-        ytmusic_client.create_playlist("PL", "d", ["v1"])
-    # Exactly one call: classified fatal, raised on first attempt.
+        ytmusic_client.add_tracks_to_playlist("PL", ["v1"])
     assert ytmusic_client.yt.add_playlist_items.call_count == 1
+
+
+def test_add_tracks_second_chunk_fails_wraps_in_chunk_error(ytmusic_client):
+    from spotify_to_ytmusic.core.config import YTMUSIC_PLAYLIST_CHUNK_SIZE
+
+    ytmusic_client.yt.add_playlist_items.side_effect = [
+        {"status": "STATUS_SUCCEEDED"},
+        *[None] * 5,
+    ]
+    video_ids = ["v" + str(i) for i in range(YTMUSIC_PLAYLIST_CHUNK_SIZE + 1)]
+    with pytest.raises(YTMusicChunkError) as exc_info:
+        ytmusic_client.add_tracks_to_playlist("PL", video_ids)
+    assert exc_info.value.chunk_index == 1
+    assert exc_info.value.total_chunks == 2
 
 
 # --- _add_chunk_with_retry -----------------------------------------------

--- a/frontend/src/hooks/useMigrationEvents.ts
+++ b/frontend/src/hooks/useMigrationEvents.ts
@@ -182,6 +182,11 @@ export function migrationReducer(
         },
       };
     }
+
+    case 'PlaylistCreationFailed':
+    case 'PlaylistChunkFailed':
+    case 'AlbumSaveFailed':
+      return { ...state, events };
   }
 }
 

--- a/frontend/src/pages/Migrate/EventLog.tsx
+++ b/frontend/src/pages/Migrate/EventLog.tsx
@@ -51,6 +51,12 @@ function formatEvent(event: MigrationEvent): string {
       };
       return `"${event.label}": ${statusLabel[event.status]}`;
     }
+    case 'PlaylistCreationFailed':
+      return `Error creando "${event.name}": ${event.reason}`;
+    case 'PlaylistChunkFailed':
+      return `Error chunk ${event.chunkIndex + 1}/${event.totalChunks} en "${event.name}": ${event.reason}`;
+    case 'AlbumSaveFailed':
+      return `Error guardando "${event.label}": ${event.reason}`;
   }
 }
 

--- a/frontend/src/types/api.test.ts
+++ b/frontend/src/types/api.test.ts
@@ -13,10 +13,12 @@ function describeEvent(event: MigrationEvent): string {
       return `discovered ${event.count} albums`;
     case 'AlbumProcessed':
       return `${event.label}: ${event.status}`;
-    default: {
-      const _exhaustive: never = event;
-      return _exhaustive;
-    }
+    case 'PlaylistCreationFailed':
+      return `failed creating ${event.name}: ${event.reason}`;
+    case 'PlaylistChunkFailed':
+      return `chunk ${event.chunkIndex}/${event.totalChunks} failed in ${event.name}`;
+    case 'AlbumSaveFailed':
+      return `failed saving ${event.label}: ${event.reason}`;
   }
 }
 
@@ -34,7 +36,10 @@ describe('MigrationEvent', () => {
       },
       { type: 'AlbumsDiscovered', count: 2 },
       { type: 'AlbumProcessed', label: 'a - b', status: 'saved' },
+      { type: 'PlaylistCreationFailed', name: 'p', reason: 'err' },
+      { type: 'PlaylistChunkFailed', name: 'p', chunkIndex: 0, totalChunks: 1, reason: 'err' },
+      { type: 'AlbumSaveFailed', label: 'a - b', reason: 'err' },
     ];
-    expect(events.map(describeEvent)).toHaveLength(5);
+    expect(events.map(describeEvent)).toHaveLength(8);
   });
 });

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -84,6 +84,26 @@ export interface AlbumProcessedEvent {
   status: AlbumStatus;
 }
 
+export interface PlaylistCreationFailedEvent {
+  type: 'PlaylistCreationFailed';
+  name: string;
+  reason: string;
+}
+
+export interface PlaylistChunkFailedEvent {
+  type: 'PlaylistChunkFailed';
+  name: string;
+  chunkIndex: number;
+  totalChunks: number;
+  reason: string;
+}
+
+export interface AlbumSaveFailedEvent {
+  type: 'AlbumSaveFailed';
+  label: string;
+  reason: string;
+}
+
 export interface HealthResponse {
   ok: boolean;
   spotify?: boolean;
@@ -95,4 +115,7 @@ export type MigrationEvent =
   | PlaylistStartedEvent
   | PlaylistFinishedEvent
   | AlbumsDiscoveredEvent
-  | AlbumProcessedEvent;
+  | AlbumProcessedEvent
+  | PlaylistCreationFailedEvent
+  | PlaylistChunkFailedEvent
+  | AlbumSaveFailedEvent;


### PR DESCRIPTION
## Summary

- **#64**: Split `create_playlist` into `create_playlist` + `add_tracks_to_playlist` so the Migrator can distinguish playlist creation failures from chunk-add failures. Added `PlaylistCreationFailed`, `PlaylistChunkFailed`, and `AlbumSaveFailed` events emitted via `on_event`. CLI renders them in Spanish. Frontend `types/api.ts` mirrors the new variants.
- **#65**: `save_report` now writes to a `.tmp` file first and uses `os.replace` for atomic persistence. Also cleans orphaned `.tmp` files from previous interrupted runs.
- **#66**: Expanded test suite from 27 to 65 tests. Added Spotify API fixtures (new `item.item` and legacy `item.track` shapes), tests for `SpotifyClient`, `TrackCache`, `Migrator` event ordering/cache hits/empty id handling, a `duplicates=True` regression test, and a GitHub Actions workflow for backend tests.

## Closes

Closes #64
Closes #65
Closes #66

## Test plan

- [x] `pytest` desde `backend/` en verde (65 tests)
- [x] VerificaciÃ³n manual: `python backend/main.py --playlists` con una playlist pequeÃ±a para confirmar que los nuevos eventos de error se renderizan correctamente en la CLI
