### PR TITLE
feat(api): add read-only routes, POST /migrate, and WS event streaming

### DIFF
--- a/backend/src/spotify_to_ytmusic/api/__init__.py
+++ b/backend/src/spotify_to_ytmusic/api/__init__.py
@@ -22,9 +22,15 @@ def create_app() -> FastAPI:
 
     from spotify_to_ytmusic.api.routes.health import router as health_router
     from spotify_to_ytmusic.api.routes.auth import router as auth_router
+    from spotify_to_ytmusic.api.routes.library import router as library_router
+    from spotify_to_ytmusic.api.routes.reports import router as reports_router
+    from spotify_to_ytmusic.api.routes.migrate import router as migrate_router
 
     app.include_router(health_router)
     app.include_router(auth_router)
+    app.include_router(library_router)
+    app.include_router(reports_router)
+    app.include_router(migrate_router)
 
     return app
 

--- a/backend/src/spotify_to_ytmusic/api/dependencies.py
+++ b/backend/src/spotify_to_ytmusic/api/dependencies.py
@@ -1,0 +1,39 @@
+"""FastAPI dependencies for shared resources."""
+import os
+
+from fastapi import Depends, HTTPException, status
+from spotipy.oauth2 import SpotifyOauthError
+
+from spotify_to_ytmusic.core.config import (
+    DEFAULT_SPOTIFY_REDIRECT_URI,
+    SPOTIFY_TOKEN_CACHE_FILE,
+)
+from spotify_to_ytmusic.core.spotify_client import SpotifyClient
+
+_spotify_client: SpotifyClient | None = None
+
+
+def get_spotify_client() -> SpotifyClient:
+    global _spotify_client
+    if _spotify_client is None:
+        client_id = os.getenv("SPOTIFY_CLIENT_ID", "")
+        client_secret = os.getenv("SPOTIFY_CLIENT_SECRET", "")
+        redirect_uri = os.getenv("SPOTIFY_REDIRECT_URI", DEFAULT_SPOTIFY_REDIRECT_URI)
+        try:
+            _spotify_client = SpotifyClient(
+                client_id=client_id,
+                client_secret=client_secret,
+                redirect_uri=redirect_uri,
+                open_browser=False,
+            )
+        except SpotifyOauthError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail={"message": f"Spotify authentication not available: {exc}"},
+            ) from exc
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail={"message": f"Spotify client unavailable: {exc}"},
+            ) from exc
+    return _spotify_client

--- a/backend/src/spotify_to_ytmusic/api/jobs.py
+++ b/backend/src/spotify_to_ytmusic/api/jobs.py
@@ -1,0 +1,60 @@
+"""Job registry for tracking active and completed migration jobs."""
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+JOB_TTL_SECONDS = 600
+
+
+@dataclass
+class JobState:
+    queue: "asyncio.Queue[Any]"
+    task: asyncio.Task | None = None
+    finished_at: float | None = None
+
+
+class JobRegistry:
+    def __init__(self, ttl_seconds: int = JOB_TTL_SECONDS) -> None:
+        self._jobs: dict[str, JobState] = {}
+        self._ttl = ttl_seconds
+
+    @property
+    def active_job_id(self) -> str | None:
+        for job_id, state in self._jobs.items():
+            if state.finished_at is None:
+                return job_id
+        return None
+
+    def register(self, job_id: str, queue: "asyncio.Queue[Any]") -> None:
+        self._jobs[job_id] = JobState(queue=queue)
+
+    def get(self, job_id: str) -> JobState | None:
+        self._cleanup_expired()
+        return self._jobs.get(job_id)
+
+    def mark_finished(self, job_id: str) -> None:
+        state = self._jobs.get(job_id)
+        if state:
+            state.finished_at = time.time()
+
+    def set_task(self, job_id: str, task: asyncio.Task) -> None:
+        state = self._jobs.get(job_id)
+        if state:
+            state.task = task
+
+    def remove(self, job_id: str) -> None:
+        self._jobs.pop(job_id, None)
+
+    def _cleanup_expired(self) -> None:
+        now = time.time()
+        expired = [
+            jid
+            for jid, state in self._jobs.items()
+            if state.finished_at is not None and now - state.finished_at > self._ttl
+        ]
+        for jid in expired:
+            self._jobs.pop(jid, None)
+
+
+registry = JobRegistry()

--- a/backend/src/spotify_to_ytmusic/api/models.py
+++ b/backend/src/spotify_to_ytmusic/api/models.py
@@ -26,3 +26,60 @@ class OkResponse(APIBase):
 
 class ErrorResponse(APIBase):
     message: str
+
+
+class PlaylistSummaryResponse(APIBase):
+    id: str
+    name: str
+    description: str
+    track_count: int
+    owner_id: str
+    is_own: bool
+
+
+class AlbumResponse(APIBase):
+    name: str
+    artist: str
+    spotify_id: str
+
+
+class PlaylistMigrationResultResponse(APIBase):
+    name: str
+    total: int
+    found: int
+    yt_playlist_id: str | None
+    error: str | None = None
+
+
+class AlbumMigrationResultResponse(APIBase):
+    label: str
+    status: str
+    error: str | None = None
+
+
+class MissingItemResponse(APIBase):
+    context: str
+    item: str
+
+
+class ReportSummaryResponse(APIBase):
+    id: str
+    playlists: list[PlaylistMigrationResultResponse]
+    albums: list[AlbumMigrationResultResponse]
+    not_found: list[MissingItemResponse]
+
+
+class ReportDetailResponse(APIBase):
+    id: str
+    playlists: list[PlaylistMigrationResultResponse]
+    albums: list[AlbumMigrationResultResponse]
+    not_found: list[MissingItemResponse]
+
+
+class MigrateRequest(APIBase):
+    playlist_ids: list[str]
+    album_ids: list[str]
+
+
+class MigrateResponse(APIBase):
+    job_id: str

--- a/backend/src/spotify_to_ytmusic/api/routes/library.py
+++ b/backend/src/spotify_to_ytmusic/api/routes/library.py
@@ -1,0 +1,54 @@
+"""Library routes: playlists and saved albums."""
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from spotify_to_ytmusic.api.dependencies import get_spotify_client
+from spotify_to_ytmusic.api.models import AlbumResponse, PlaylistSummaryResponse
+from spotify_to_ytmusic.core.spotify_client import SpotifyClient
+
+router = APIRouter(prefix="/api")
+
+
+@router.get("/playlists", response_model=list[PlaylistSummaryResponse])
+async def get_playlists(
+    spotify: SpotifyClient = Depends(get_spotify_client),
+) -> list[PlaylistSummaryResponse]:
+    try:
+        user_id = spotify.get_current_user_id()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"message": f"Spotify auth unavailable: {exc}"},
+        )
+    summaries = spotify.list_playlist_summaries(user_id)
+    return [
+        PlaylistSummaryResponse(
+            id=s.id,
+            name=s.name,
+            description=s.description,
+            track_count=s.track_count,
+            owner_id=s.owner_id,
+            is_own=s.is_own,
+        )
+        for s in summaries
+    ]
+
+
+@router.get("/albums", response_model=list[AlbumResponse])
+async def get_albums(
+    spotify: SpotifyClient = Depends(get_spotify_client),
+) -> list[AlbumResponse]:
+    try:
+        albums = spotify.get_saved_albums()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"message": f"Spotify auth unavailable: {exc}"},
+        )
+    return [
+        AlbumResponse(
+            name=a.name,
+            artist=a.artist,
+            spotify_id=a.spotify_id,
+        )
+        for a in albums
+    ]

--- a/backend/src/spotify_to_ytmusic/api/routes/migrate.py
+++ b/backend/src/spotify_to_ytmusic/api/routes/migrate.py
@@ -1,0 +1,113 @@
+"""Migration routes: POST /migrate and WS /migrate/:jobId/events."""
+import asyncio
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect, status
+
+from spotify_to_ytmusic.api.jobs import JobState, registry
+from spotify_to_ytmusic.api.models import ErrorResponse, MigrateRequest, MigrateResponse
+from spotify_to_ytmusic.api.serialization import serialize_event
+from spotify_to_ytmusic.core.config import (
+    BROWSER_AUTH_FILE,
+    DEFAULT_SPOTIFY_REDIRECT_URI,
+    SPOTIFY_TOKEN_CACHE_FILE,
+    TRACK_CACHE_FILE,
+)
+from spotify_to_ytmusic.core.events import MigrationFinished
+from spotify_to_ytmusic.core.migrator import Migrator
+from spotify_to_ytmusic.core.report import save_report
+from spotify_to_ytmusic.core.spotify_client import SpotifyClient
+from spotify_to_ytmusic.core.track_cache import TrackCache
+from spotify_to_ytmusic.core.ytmusic_client import YTMusicClient
+
+router = APIRouter(prefix="/api")
+
+_executor = ThreadPoolExecutor(max_workers=1)
+
+
+def _run_migration(
+    job_id: str,
+    playlist_ids: list[str],
+    album_ids: list[str],
+) -> None:
+    import os
+
+    state = registry.get(job_id)
+    if state is None:
+        return
+
+    spotify = SpotifyClient(
+        client_id=os.getenv("SPOTIFY_CLIENT_ID", ""),
+        client_secret=os.getenv("SPOTIFY_CLIENT_SECRET", ""),
+        redirect_uri=os.getenv("SPOTIFY_REDIRECT_URI", DEFAULT_SPOTIFY_REDIRECT_URI),
+        open_browser=False,
+    )
+    ytmusic = YTMusicClient(BROWSER_AUTH_FILE)
+    cache = TrackCache(Path(TRACK_CACHE_FILE))
+
+    def on_event(event) -> None:
+        state.queue.put_nowait(event)
+
+    migrator = Migrator(
+        spotify=spotify,
+        ytmusic=ytmusic,
+        on_event=on_event,
+        cache=cache,
+    )
+
+    if playlist_ids:
+        migrator.migrate_playlists(playlist_ids)
+    if album_ids:
+        migrator.migrate_albums()
+
+    report_path = save_report(migrator.report)
+    report_id = report_path.stem.replace("migration_report_", "")
+    state.queue.put_nowait(MigrationFinished(report_id=report_id))
+    registry.mark_finished(job_id)
+
+
+@router.post("/migrate", response_model=MigrateResponse, status_code=status.HTTP_201_CREATED)
+async def start_migration(body: MigrateRequest) -> MigrateResponse | ErrorResponse:
+    if registry.active_job_id is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"message": "A migration job is already running"},
+        )
+
+    job_id = uuid.uuid4().hex
+    queue: asyncio.Queue = asyncio.Queue()
+    registry.register(job_id, queue)
+
+    loop = asyncio.get_running_loop()
+    task = loop.run_in_executor(
+        _executor,
+        _run_migration,
+        job_id,
+        body.playlist_ids,
+        body.album_ids,
+    )
+    registry.set_task(job_id, task)
+
+    return MigrateResponse(job_id=job_id)
+
+
+@router.websocket("/migrate/{job_id}/events")
+async def migration_events(websocket: WebSocket, job_id: str) -> None:
+    state = registry.get(job_id)
+    if state is None:
+        await websocket.close(code=4404)
+        return
+
+    await websocket.accept()
+
+    try:
+        while True:
+            event = await state.queue.get()
+            await websocket.send_json(serialize_event(event))
+            if isinstance(event, MigrationFinished):
+                await websocket.close()
+                return
+    except WebSocketDisconnect:
+        return

--- a/backend/src/spotify_to_ytmusic/api/routes/reports.py
+++ b/backend/src/spotify_to_ytmusic/api/routes/reports.py
@@ -1,0 +1,58 @@
+"""Reports routes: list and detail."""
+from fastapi import APIRouter, HTTPException, status
+
+from spotify_to_ytmusic.api.models import (
+    AlbumMigrationResultResponse,
+    MissingItemResponse,
+    PlaylistMigrationResultResponse,
+    ReportDetailResponse,
+    ReportSummaryResponse,
+)
+from spotify_to_ytmusic.core.report import list_reports, load_report
+
+router = APIRouter(prefix="/api")
+
+
+def _to_report_summary_response(report) -> ReportSummaryResponse:
+    return ReportSummaryResponse(
+        id=report.id or "",
+        playlists=[
+            PlaylistMigrationResultResponse(
+                name=p.name,
+                total=p.total,
+                found=p.found,
+                yt_playlist_id=p.yt_playlist_id,
+                error=p.error,
+            )
+            for p in report.playlists
+        ],
+        albums=[
+            AlbumMigrationResultResponse(
+                label=a.label,
+                status=a.status,
+                error=a.error,
+            )
+            for a in report.albums
+        ],
+        not_found=[
+            MissingItemResponse(context=n.context, item=n.item)
+            for n in report.not_found
+        ],
+    )
+
+
+@router.get("/reports", response_model=list[ReportSummaryResponse])
+async def get_reports() -> list[ReportSummaryResponse]:
+    reports = list_reports()
+    return [_to_report_summary_response(r) for r in reports]
+
+
+@router.get("/reports/{report_id}", response_model=ReportDetailResponse)
+async def get_report(report_id: str) -> ReportDetailResponse:
+    report = load_report(report_id)
+    if report is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"message": f"Report '{report_id}' not found"},
+        )
+    return _to_report_summary_response(report)

--- a/backend/src/spotify_to_ytmusic/api/serialization.py
+++ b/backend/src/spotify_to_ytmusic/api/serialization.py
@@ -1,0 +1,26 @@
+"""Serialize MigrationEvent dataclasses to camelCase dicts for WS transport."""
+from dataclasses import asdict, fields
+
+from spotify_to_ytmusic.core.events import (
+    AlbumProcessed,
+    AlbumSaveFailed,
+    AlbumsDiscovered,
+    MigrationEvent,
+    MigrationFinished,
+    PlaylistChunkFailed,
+    PlaylistCreationFailed,
+    PlaylistFinished,
+    PlaylistStarted,
+    PlaylistsDiscovered,
+)
+
+
+def _to_camel(s: str) -> str:
+    parts = s.split("_")
+    return parts[0] + "".join(p.capitalize() for p in parts[1:])
+
+
+def serialize_event(event: MigrationEvent) -> dict:
+    cls = type(event).__name__
+    data = asdict(event)
+    return {"type": cls, **{_to_camel(k): v for k, v in data.items()}}

--- a/backend/src/spotify_to_ytmusic/core/events.py
+++ b/backend/src/spotify_to_ytmusic/core/events.py
@@ -53,6 +53,11 @@ class AlbumSaveFailed:
     reason: str
 
 
+@dataclass
+class MigrationFinished:
+    report_id: str
+
+
 MigrationEvent = Union[
     PlaylistsDiscovered,
     PlaylistStarted,
@@ -62,6 +67,7 @@ MigrationEvent = Union[
     PlaylistCreationFailed,
     PlaylistChunkFailed,
     AlbumSaveFailed,
+    MigrationFinished,
 ]
 
 EventCallback = Callable[[MigrationEvent], None]

--- a/backend/src/spotify_to_ytmusic/core/models.py
+++ b/backend/src/spotify_to_ytmusic/core/models.py
@@ -68,6 +68,7 @@ class MissingItem:
 
 @dataclass
 class MigrationReport:
+    id: str | None = None
     playlists: list[PlaylistMigrationResult] = field(default_factory=list)
     albums: list[AlbumMigrationResult] = field(default_factory=list)
     not_found: list[MissingItem] = field(default_factory=list)

--- a/backend/src/spotify_to_ytmusic/core/report.py
+++ b/backend/src/spotify_to_ytmusic/core/report.py
@@ -1,12 +1,20 @@
 """Persists MigrationReport instances to disk as JSON."""
 import json
 import os
+import re
 from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
 
 from spotify_to_ytmusic.core.config import DATA_DIR
-from spotify_to_ytmusic.core.models import MigrationReport
+from spotify_to_ytmusic.core.models import (
+    AlbumMigrationResult,
+    MigrationReport,
+    MissingItem,
+    PlaylistMigrationResult,
+)
+
+_REPORT_RE = re.compile(r"^migration_report_(\d{8}_\d{6})\.json$")
 
 
 def save_report(report: MigrationReport, directory: Path | str | None = None) -> Path:
@@ -28,3 +36,60 @@ def save_report(report: MigrationReport, directory: Path | str | None = None) ->
         json.dump(payload, f, indent=2, ensure_ascii=False)
     os.replace(tmp, path)
     return path
+
+
+def list_reports(directory: Path | str | None = None) -> list[MigrationReport]:
+    target_dir = Path(directory) if directory is not None else DATA_DIR
+    if not target_dir.exists():
+        return []
+
+    reports: list[MigrationReport] = []
+    for entry in sorted(target_dir.glob("migration_report_*.json"), reverse=True):
+        match = _REPORT_RE.match(entry.name)
+        if not match:
+            continue
+        try:
+            with open(entry, encoding="utf-8") as f:
+                data = json.load(f)
+            reports.append(_parse_report(data, match.group(1)))
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return reports
+
+
+def load_report(report_id: str, directory: Path | str | None = None) -> MigrationReport | None:
+    target_dir = Path(directory) if directory is not None else DATA_DIR
+    path = target_dir / f"migration_report_{report_id}.json"
+    if not path.exists():
+        return None
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    return _parse_report(data, report_id)
+
+
+def _parse_report(data: dict, report_id: str) -> MigrationReport:
+    return MigrationReport(
+        id=report_id,
+        playlists=[
+            PlaylistMigrationResult(
+                name=p["name"],
+                total=p["total"],
+                found=p["found"],
+                yt_playlist_id=p.get("yt_playlist_id"),
+                error=p.get("error"),
+            )
+            for p in data.get("playlists", [])
+        ],
+        albums=[
+            AlbumMigrationResult(
+                label=a["label"],
+                status=a["status"],
+                error=a.get("error"),
+            )
+            for a in data.get("albums", [])
+        ],
+        not_found=[
+            MissingItem(context=n["context"], item=n["item"])
+            for n in data.get("not_found", [])
+        ],
+    )

--- a/backend/src/spotify_to_ytmusic/core/spotify_client.py
+++ b/backend/src/spotify_to_ytmusic/core/spotify_client.py
@@ -17,14 +17,14 @@ from spotify_to_ytmusic.core.models import Album, Playlist, PlaylistSummary, Tra
 
 
 class SpotifyClient:
-    def __init__(self, client_id: str, client_secret: str, redirect_uri: str):
+    def __init__(self, client_id: str, client_secret: str, redirect_uri: str, open_browser: bool = True):
         self.sp = spotipy.Spotify(auth_manager=SpotifyOAuth(
             client_id=client_id,
             client_secret=client_secret,
             redirect_uri=redirect_uri,
             scope=SPOTIFY_SCOPES,
             cache_path=SPOTIFY_TOKEN_CACHE_FILE,
-            open_browser=True,
+            open_browser=open_browser,
         ))
 
     def get_current_user_id(self) -> str:

--- a/backend/tests/api/test_library.py
+++ b/backend/tests/api/test_library.py
@@ -1,0 +1,129 @@
+"""Integration tests for /api/playlists and /api/albums."""
+from unittest.mock import patch, MagicMock
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from spotify_to_ytmusic.api import create_app
+from spotify_to_ytmusic.core.models import PlaylistSummary, Album
+
+
+@pytest.fixture
+def app():
+    return create_app()
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _reset_spotify_singleton():
+    import spotify_to_ytmusic.api.dependencies as deps
+    deps._spotify_client = None
+    yield
+    deps._spotify_client = None
+
+
+def _mock_spotify_client():
+    client = MagicMock()
+    client.get_current_user_id.return_value = "test_user"
+    client.list_playlist_summaries.return_value = [
+        PlaylistSummary(
+            id="pl_1",
+            name="My Playlist",
+            description="A test playlist",
+            track_count=10,
+            owner_id="test_user",
+            is_own=True,
+        ),
+        PlaylistSummary(
+            id="pl_2",
+            name="Collab",
+            description="",
+            track_count=5,
+            owner_id="other_user",
+            is_own=False,
+        ),
+    ]
+    client.get_saved_albums.return_value = [
+        Album(name="In Rainbows", artist="Radiohead", spotify_id="alb_1"),
+        Album(name="Currents", artist="Tame Impala", spotify_id="alb_2"),
+    ]
+    return client
+
+
+@pytest.mark.asyncio
+async def test_get_playlists_returns_200(client):
+    mock_client = _mock_spotify_client()
+    with patch("spotify_to_ytmusic.api.dependencies.SpotifyClient", return_value=mock_client):
+        resp = await client.get("/api/playlists")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        assert data[0]["id"] == "pl_1"
+        assert data[0]["name"] == "My Playlist"
+        assert data[0]["trackCount"] == 10
+        assert data[0]["isOwn"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_playlists_camel_case(client):
+    mock_client = _mock_spotify_client()
+    with patch("spotify_to_ytmusic.api.dependencies.SpotifyClient", return_value=mock_client):
+        resp = await client.get("/api/playlists")
+        data = resp.json()
+        for item in data:
+            assert "trackCount" in item
+            assert "ownerId" in item
+            assert "isOwn" in item
+
+
+@pytest.mark.asyncio
+async def test_get_playlists_401_on_auth_failure(client):
+    with patch(
+        "spotify_to_ytmusic.api.dependencies.SpotifyClient",
+        side_effect=Exception("No credentials"),
+    ):
+        resp = await client.get("/api/playlists")
+        assert resp.status_code == 401
+        data = resp.json()
+        assert "message" in data["detail"]
+
+
+@pytest.mark.asyncio
+async def test_get_albums_returns_200(client):
+    mock_client = _mock_spotify_client()
+    with patch("spotify_to_ytmusic.api.dependencies.SpotifyClient", return_value=mock_client):
+        resp = await client.get("/api/albums")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        assert data[0]["name"] == "In Rainbows"
+        assert data[0]["artist"] == "Radiohead"
+        assert data[0]["spotifyId"] == "alb_1"
+
+
+@pytest.mark.asyncio
+async def test_get_albums_camel_case(client):
+    mock_client = _mock_spotify_client()
+    with patch("spotify_to_ytmusic.api.dependencies.SpotifyClient", return_value=mock_client):
+        resp = await client.get("/api/albums")
+        data = resp.json()
+        for item in data:
+            assert "spotifyId" in item
+
+
+@pytest.mark.asyncio
+async def test_get_albums_401_on_auth_failure(client):
+    with patch(
+        "spotify_to_ytmusic.api.dependencies.SpotifyClient",
+        side_effect=Exception("No credentials"),
+    ):
+        resp = await client.get("/api/albums")
+        assert resp.status_code == 401
+        data = resp.json()
+        assert "message" in data["detail"]

--- a/backend/tests/api/test_migrate.py
+++ b/backend/tests/api/test_migrate.py
@@ -1,0 +1,104 @@
+"""Integration tests for /api/migrate and WS /api/migrate/:jobId/events."""
+import asyncio
+from unittest.mock import patch, MagicMock
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from starlette.testclient import TestClient
+
+from spotify_to_ytmusic.api import create_app
+from spotify_to_ytmusic.api.jobs import registry
+import spotify_to_ytmusic.api.dependencies as deps
+
+
+@pytest.fixture
+def app():
+    return create_app()
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    registry._jobs.clear()
+    yield
+    registry._jobs.clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_spotify_singleton():
+    deps._spotify_client = None
+    yield
+    deps._spotify_client = None
+
+
+@pytest.mark.asyncio
+async def test_start_migration_returns_201(client):
+    with patch("spotify_to_ytmusic.api.routes.migrate._run_migration"):
+        resp = await client.post(
+            "/api/migrate",
+            json={"playlistIds": ["pl_1"], "albumIds": []},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert "jobId" in data
+        assert len(data["jobId"]) == 32
+
+
+@pytest.mark.asyncio
+async def test_start_migration_409_when_job_running(client):
+    registry.register("existing-job", asyncio.Queue())
+    resp = await client.post(
+        "/api/migrate",
+        json={"playlistIds": ["pl_1"], "albumIds": []},
+    )
+    assert resp.status_code == 409
+    data = resp.json()
+    assert "message" in data["detail"]
+
+
+@pytest.mark.asyncio
+async def test_start_migration_camel_case(client):
+    with patch("spotify_to_ytmusic.api.routes.migrate._run_migration"):
+        resp = await client.post(
+            "/api/migrate",
+            json={"playlistIds": ["pl_1"], "albumIds": []},
+        )
+        data = resp.json()
+        assert "jobId" in data
+
+
+def test_ws_unknown_job_id_closes_4404(app):
+    with TestClient(app) as tc:
+        with pytest.raises(Exception):
+            with tc.websocket_connect("/api/migrate/nonexistent/events") as ws:
+                ws.receive_text()
+
+
+def test_ws_delivers_events_and_closes_on_finished(app):
+    job_id = "test-job-123"
+    queue: asyncio.Queue = asyncio.Queue()
+    registry.register(job_id, queue)
+
+    from spotify_to_ytmusic.core.events import (
+        PlaylistsDiscovered,
+        MigrationFinished,
+    )
+
+    with TestClient(app) as tc:
+        with tc.websocket_connect(f"/api/migrate/{job_id}/events") as ws:
+            queue.put_nowait(PlaylistsDiscovered(count=2))
+            queue.put_nowait(MigrationFinished(report_id="20260306_141532"))
+
+            msg1 = ws.receive_json()
+            assert msg1["type"] == "PlaylistsDiscovered"
+            assert msg1["count"] == 2
+
+            msg2 = ws.receive_json()
+            assert msg2["type"] == "MigrationFinished"
+            assert msg2["reportId"] == "20260306_141532"

--- a/backend/tests/api/test_reports.py
+++ b/backend/tests/api/test_reports.py
@@ -1,0 +1,137 @@
+"""Integration tests for /api/reports and /api/reports/:id."""
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from spotify_to_ytmusic.api import create_app
+
+
+@pytest.fixture
+def app():
+    return create_app()
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture
+def report_dir(tmp_path: Path) -> Path:
+    r1 = tmp_path / "migration_report_20260306_141532.json"
+    r1.write_text(json.dumps({
+        "playlists": [
+            {"name": "Mix 1", "total": 10, "found": 8, "yt_playlist_id": "PL_abc", "error": None}
+        ],
+        "albums": [{"label": "Radiohead - In Rainbows", "status": "saved", "error": None}],
+        "not_found": [{"context": "Mix 1", "item": "Unknown - Track"}],
+    }))
+    r2 = tmp_path / "migration_report_20260305_100000.json"
+    r2.write_text(json.dumps({
+        "playlists": [],
+        "albums": [],
+        "not_found": [],
+    }))
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_get_reports_returns_list(client, report_dir):
+    with patch("spotify_to_ytmusic.api.routes.reports.list_reports") as mock_list:
+        from spotify_to_ytmusic.core.models import (
+            MigrationReport,
+            PlaylistMigrationResult,
+            AlbumMigrationResult,
+            MissingItem,
+        )
+        mock_list.return_value = [
+            MigrationReport(
+                id="20260306_141532",
+                playlists=[
+                    PlaylistMigrationResult(
+                        name="Mix 1", total=10, found=8, yt_playlist_id="PL_abc", error=None
+                    )
+                ],
+                albums=[AlbumMigrationResult(label="Radiohead - In Rainbows", status="saved", error=None)],
+                not_found=[MissingItem(context="Mix 1", item="Unknown - Track")],
+            ),
+            MigrationReport(
+                id="20260305_100000",
+                playlists=[],
+                albums=[],
+                not_found=[],
+            ),
+        ]
+        resp = await client.get("/api/reports")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        assert data[0]["id"] == "20260306_141532"
+        assert data[1]["id"] == "20260305_100000"
+
+
+@pytest.mark.asyncio
+async def test_get_reports_empty(client):
+    with patch("spotify_to_ytmusic.api.routes.reports.list_reports", return_value=[]):
+        resp = await client.get("/api/reports")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == []
+
+
+@pytest.mark.asyncio
+async def test_get_reports_camel_case(client):
+    with patch("spotify_to_ytmusic.api.routes.reports.list_reports") as mock_list:
+        from spotify_to_ytmusic.core.models import (
+            MigrationReport,
+            PlaylistMigrationResult,
+            AlbumMigrationResult,
+            MissingItem,
+        )
+        mock_list.return_value = [
+            MigrationReport(
+                id="20260306_141532",
+                playlists=[
+                    PlaylistMigrationResult(
+                        name="Mix 1", total=10, found=8, yt_playlist_id="PL_abc", error=None
+                    )
+                ],
+                albums=[AlbumMigrationResult(label="Radiohead - In Rainbows", status="saved", error=None)],
+                not_found=[MissingItem(context="Mix 1", item="Unknown - Track")],
+            ),
+        ]
+        resp = await client.get("/api/reports")
+        data = resp.json()
+        item = data[0]
+        assert "ytPlaylistId" in item["playlists"][0]
+        assert "notFound" in item
+
+
+@pytest.mark.asyncio
+async def test_get_report_by_id(client):
+    with patch("spotify_to_ytmusic.api.routes.reports.load_report") as mock_load:
+        from spotify_to_ytmusic.core.models import MigrationReport
+        mock_load.return_value = MigrationReport(
+            id="20260306_141532",
+            playlists=[],
+            albums=[],
+            not_found=[],
+        )
+        resp = await client.get("/api/reports/20260306_141532")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == "20260306_141532"
+
+
+@pytest.mark.asyncio
+async def test_get_report_by_id_404(client):
+    with patch("spotify_to_ytmusic.api.routes.reports.load_report", return_value=None):
+        resp = await client.get("/api/reports/nonexistent")
+        assert resp.status_code == 404
+        data = resp.json()
+        assert "message" in data["detail"]

--- a/backend/tests/api/test_serialization.py
+++ b/backend/tests/api/test_serialization.py
@@ -1,0 +1,59 @@
+"""Tests for event serialization."""
+from spotify_to_ytmusic.api.serialization import serialize_event
+from spotify_to_ytmusic.core.events import (
+    AlbumProcessed,
+    AlbumsDiscovered,
+    MigrationFinished,
+    PlaylistFinished,
+    PlaylistStarted,
+    PlaylistsDiscovered,
+)
+
+
+def test_serialize_playlists_discovered():
+    event = PlaylistsDiscovered(count=3)
+    result = serialize_event(event)
+    assert result == {"type": "PlaylistsDiscovered", "count": 3}
+
+
+def test_serialize_playlist_started():
+    event = PlaylistStarted(name="My Mix", track_count=42)
+    result = serialize_event(event)
+    assert result == {"type": "PlaylistStarted", "name": "My Mix", "trackCount": 42}
+
+
+def test_serialize_playlist_finished():
+    event = PlaylistFinished(
+        name="My Mix",
+        found=40,
+        total=42,
+        not_found_labels=["Track A", "Track B"],
+    )
+    result = serialize_event(event)
+    assert result["type"] == "PlaylistFinished"
+    assert result["name"] == "My Mix"
+    assert result["found"] == 40
+    assert result["total"] == 42
+    assert result["notFoundLabels"] == ["Track A", "Track B"]
+
+
+def test_serialize_album_processed():
+    event = AlbumProcessed(label="Radiohead - In Rainbows", status="saved")
+    result = serialize_event(event)
+    assert result == {
+        "type": "AlbumProcessed",
+        "label": "Radiohead - In Rainbows",
+        "status": "saved",
+    }
+
+
+def test_serialize_albums_discovered():
+    event = AlbumsDiscovered(count=2)
+    result = serialize_event(event)
+    assert result == {"type": "AlbumsDiscovered", "count": 2}
+
+
+def test_serialize_migration_finished():
+    event = MigrationFinished(report_id="20260306_141532")
+    result = serialize_event(event)
+    assert result == {"type": "MigrationFinished", "reportId": "20260306_141532"}

--- a/frontend/src/hooks/useMigrationEvents.ts
+++ b/frontend/src/hooks/useMigrationEvents.ts
@@ -186,6 +186,7 @@ export function migrationReducer(
     case 'PlaylistCreationFailed':
     case 'PlaylistChunkFailed':
     case 'AlbumSaveFailed':
+    case 'MigrationFinished':
       return { ...state, events };
   }
 }

--- a/frontend/src/pages/Migrate/EventLog.tsx
+++ b/frontend/src/pages/Migrate/EventLog.tsx
@@ -57,6 +57,8 @@ function formatEvent(event: MigrationEvent): string {
       return `Error chunk ${event.chunkIndex + 1}/${event.totalChunks} en "${event.name}": ${event.reason}`;
     case 'AlbumSaveFailed':
       return `Error guardando "${event.label}": ${event.reason}`;
+    case 'MigrationFinished':
+      return `Migración completada (reporte ${event.reportId})`;
   }
 }
 

--- a/frontend/src/types/api.test.ts
+++ b/frontend/src/types/api.test.ts
@@ -19,6 +19,8 @@ function describeEvent(event: MigrationEvent): string {
       return `chunk ${event.chunkIndex}/${event.totalChunks} failed in ${event.name}`;
     case 'AlbumSaveFailed':
       return `failed saving ${event.label}: ${event.reason}`;
+    case 'MigrationFinished':
+      return `migration finished (report ${event.reportId})`;
   }
 }
 
@@ -39,7 +41,8 @@ describe('MigrationEvent', () => {
       { type: 'PlaylistCreationFailed', name: 'p', reason: 'err' },
       { type: 'PlaylistChunkFailed', name: 'p', chunkIndex: 0, totalChunks: 1, reason: 'err' },
       { type: 'AlbumSaveFailed', label: 'a - b', reason: 'err' },
+      { type: 'MigrationFinished', reportId: '20260306_141532' },
     ];
-    expect(events.map(describeEvent)).toHaveLength(8);
+    expect(events.map(describeEvent)).toHaveLength(9);
   });
 });

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -104,6 +104,11 @@ export interface AlbumSaveFailedEvent {
   reason: string;
 }
 
+export interface MigrationFinishedEvent {
+  type: 'MigrationFinished';
+  reportId: string;
+}
+
 export interface HealthResponse {
   ok: boolean;
   spotify?: boolean;
@@ -118,4 +123,5 @@ export type MigrationEvent =
   | AlbumProcessedEvent
   | PlaylistCreationFailedEvent
   | PlaylistChunkFailedEvent
-  | AlbumSaveFailedEvent;
+  | AlbumSaveFailedEvent
+  | MigrationFinishedEvent;


### PR DESCRIPTION
## Summary

- Add GET /api/playlists, GET /api/albums, GET /api/reports, GET /api/reports/:id with camelCase responses
- Add POST /api/migrate (201) with single-job limit (409) and BackgroundTask execution
- Add WS /api/migrate/:jobId/events for real-time migration event streaming
- Add JobRegistry with TTL cleanup and event serialization helper
- Add MigrationFinished event to core events union
- Add SpotifyClient dependency with 401 on auth failure and open_browser flag
- Add report helpers (list_reports, load_report) with id derived from filename
- Update frontend types with MigrationFinishedEvent

## Closes

Closes #69
Closes #70

## Test plan

- [x] \pytest\ desde \ackend/\ en verde (100 passed)
- [ ] \pnpm test:run\ en \rontend/\ en verde (si tocó frontend)
- [ ] \pnpm lint && pnpm format:check && pnpm build\ en \rontend/\ en verde
- [ ] Verificación manual: \python -m spotify_to_ytmusic.api.server\ y probar endpoints con curl/Postman