### PR TITLE
fix(ui): update connection badges on auth success and add Spotify toast

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -8,7 +8,7 @@ import vitest from '@vitest/eslint-plugin'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'src-tauri/target']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/frontend/src/features/auth/useHealth.ts
+++ b/frontend/src/features/auth/useHealth.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { http } from '@/lib/http';
 import type { HealthResponse } from '@/types/api';
 
@@ -19,7 +19,7 @@ export function useHealth(): HealthStatus {
   const { data, isLoading } = useQuery({
     queryKey: ['health'],
     queryFn: () => http.get<HealthResponse>('/health'),
-    staleTime: 10_000,
+    staleTime: 0,
     retry: false,
   });
 
@@ -31,4 +31,9 @@ export function useHealth(): HealthStatus {
     spotify: toConnectionState(data.spotify),
     ytmusic: toConnectionState(data.ytmusic),
   };
+}
+
+export function useInvalidateHealth() {
+  const queryClient = useQueryClient();
+  return () => queryClient.invalidateQueries({ queryKey: ['health'] });
 }

--- a/frontend/src/features/auth/useSpotifyAuth.test.tsx
+++ b/frontend/src/features/auth/useSpotifyAuth.test.tsx
@@ -1,8 +1,23 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ToastProvider } from '@/components/ui/Toast';
 import { server } from '@/test/msw/server';
 import { spotifyAuthErrorHandler } from '@/test/msw/handlers';
 import { useSpotifyAuth } from './useSpotifyAuth';
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>{children}</ToastProvider>
+    </QueryClientProvider>
+  );
+}
 
 let assignSpy: ReturnType<typeof vi.fn>;
 
@@ -21,13 +36,13 @@ afterEach(() => {
 
 describe('useSpotifyAuth', () => {
   it('starts in idle state', () => {
-    const { result } = renderHook(() => useSpotifyAuth());
+    const { result } = renderHook(() => useSpotifyAuth(), { wrapper });
     expect(result.current.state).toBe('idle');
     expect(result.current.errorMessage).toBeNull();
   });
 
   it('redirects to the auth URL on success', async () => {
-    const { result } = renderHook(() => useSpotifyAuth());
+    const { result } = renderHook(() => useSpotifyAuth(), { wrapper });
 
     await act(async () => {
       result.current.connect();
@@ -41,7 +56,7 @@ describe('useSpotifyAuth', () => {
   it('sets error state and message on HTTP error', async () => {
     server.use(spotifyAuthErrorHandler);
 
-    const { result } = renderHook(() => useSpotifyAuth());
+    const { result } = renderHook(() => useSpotifyAuth(), { wrapper });
 
     await act(async () => {
       result.current.connect();

--- a/frontend/src/features/auth/useSpotifyAuth.ts
+++ b/frontend/src/features/auth/useSpotifyAuth.ts
@@ -1,5 +1,7 @@
 import { useCallback, useState } from 'react';
 import { http, HttpError } from '@/lib/http';
+import { useToast } from '@/lib/useToast';
+import { useInvalidateHealth } from './useHealth';
 
 export type AuthState = 'idle' | 'starting' | 'success' | 'error';
 
@@ -12,6 +14,8 @@ export interface UseSpotifyAuthResult {
 export function useSpotifyAuth(): UseSpotifyAuthResult {
   const [state, setState] = useState<AuthState>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const toast = useToast();
+  const invalidateHealth = useInvalidateHealth();
 
   const connect = useCallback(() => {
     setState('starting');
@@ -21,6 +25,8 @@ export function useSpotifyAuth(): UseSpotifyAuthResult {
       .post<{ url: string }>('/auth/spotify')
       .then(({ url }) => {
         setState('success');
+        invalidateHealth();
+        toast.success('Conectado a Spotify. Serás redirigido para autorizar.');
         window.location.assign(url);
       })
       .catch((err: unknown) => {

--- a/frontend/src/features/auth/useSpotifyAuth.ts
+++ b/frontend/src/features/auth/useSpotifyAuth.ts
@@ -42,7 +42,7 @@ export function useSpotifyAuth(): UseSpotifyAuthResult {
           setErrorMessage('No se pudo conectar. Comprueba tu conexión e inténtalo de nuevo.');
         }
       });
-  }, []);
+  }, [invalidateHealth, toast]);
 
   return { state, errorMessage, connect };
 }

--- a/frontend/src/features/auth/useYTMusicAuth.test.tsx
+++ b/frontend/src/features/auth/useYTMusicAuth.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ToastProvider } from '@/components/ui/Toast';
 import { server } from '@/test/msw/server';
 import { ytmusicAuthErrorHandler } from '@/test/msw/handlers';
@@ -8,8 +9,16 @@ import { useYTMusicAuth } from './useYTMusicAuth';
 
 const VALID_HEADERS = 'cookie: sid=abc\nuser-agent: Mozilla/5.0';
 
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
 function wrapper({ children }: { children: ReactNode }) {
-  return <ToastProvider>{children}</ToastProvider>;
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>{children}</ToastProvider>
+    </QueryClientProvider>
+  );
 }
 
 afterEach(() => {

--- a/frontend/src/features/auth/useYTMusicAuth.ts
+++ b/frontend/src/features/auth/useYTMusicAuth.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import { http, HttpError } from '@/lib/http';
 import { useToast } from '@/lib/useToast';
+import { useInvalidateHealth } from './useHealth';
 
 export type AuthState = 'idle' | 'submitting' | 'success' | 'error';
 
@@ -19,6 +20,7 @@ export function useYTMusicAuth(): UseYTMusicAuthResult {
   const [state, setState] = useState<AuthState>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const toast = useToast();
+  const invalidateHealth = useInvalidateHealth();
 
   const connect = useCallback(
     (headers: string) => {
@@ -34,6 +36,7 @@ export function useYTMusicAuth(): UseYTMusicAuthResult {
         .post('/auth/ytmusic', { headers })
         .then(() => {
           setState('success');
+          invalidateHealth();
           toast.success('YouTube Music conectado');
         })
         .catch((err: unknown) => {

--- a/frontend/src/features/auth/useYTMusicAuth.ts
+++ b/frontend/src/features/auth/useYTMusicAuth.ts
@@ -11,11 +11,6 @@ export interface UseYTMusicAuthResult {
   connect: (headers: string) => void;
 }
 
-function isValidHeaders(headers: string): boolean {
-  const lower = headers.toLowerCase();
-  return lower.includes('cookie:') && lower.includes('user-agent:');
-}
-
 export function useYTMusicAuth(): UseYTMusicAuthResult {
   const [state, setState] = useState<AuthState>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -53,7 +48,7 @@ export function useYTMusicAuth(): UseYTMusicAuthResult {
           }
         });
     },
-    [toast],
+    [toast, invalidateHealth],
   );
 
   return { state, errorMessage, connect };

--- a/frontend/src/pages/Connect/Spotify.test.tsx
+++ b/frontend/src/pages/Connect/Spotify.test.tsx
@@ -1,8 +1,23 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ToastProvider } from '@/components/ui/Toast';
 import { server } from '@/test/msw/server';
 import { spotifyAuthErrorHandler } from '@/test/msw/handlers';
 import { SpotifyConnect } from './Spotify';
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>{children}</ToastProvider>
+    </QueryClientProvider>
+  );
+}
 
 vi.mock('@/features/auth/useSpotifySetup', () => ({
   useSpotifySetup: () => ({ configured: true, state: 'idle' as const, errorMessage: null, save: vi.fn() }),
@@ -25,12 +40,12 @@ afterEach(() => {
 
 describe('SpotifyConnect', () => {
   it('renders the connect button', () => {
-    render(<SpotifyConnect />);
+    render(<SpotifyConnect />, { wrapper });
     expect(screen.getByRole('button', { name: /conectar con spotify/i })).toBeInTheDocument();
   });
 
   it('redirects to the auth URL on success', async () => {
-    render(<SpotifyConnect />);
+    render(<SpotifyConnect />, { wrapper });
     fireEvent.click(screen.getByRole('button', { name: /conectar con spotify/i }));
 
     await waitFor(() => {
@@ -41,7 +56,7 @@ describe('SpotifyConnect', () => {
 
   it('shows an error message on failure', async () => {
     server.use(spotifyAuthErrorHandler);
-    render(<SpotifyConnect />);
+    render(<SpotifyConnect />, { wrapper });
     fireEvent.click(screen.getByRole('button', { name: /conectar con spotify/i }));
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Error de configuración');

--- a/frontend/src/pages/Connect/YTMusic.test.tsx
+++ b/frontend/src/pages/Connect/YTMusic.test.tsx
@@ -1,17 +1,24 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ToastContainer, ToastProvider } from '@/components/ui/Toast';
 import { server } from '@/test/msw/server';
 import { ytmusicAuthErrorHandler } from '@/test/msw/handlers';
 import { YTMusicConnect } from './YTMusic';
 
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
 function wrapper({ children }: { children: ReactNode }) {
   return (
-    <ToastProvider>
-      {children}
-      <ToastContainer />
-    </ToastProvider>
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>
+        {children}
+        <ToastContainer />
+      </ToastProvider>
+    </QueryClientProvider>
   );
 }
 


### PR DESCRIPTION
## Summary

- `useHealth`: `staleTime=0` for instant badge updates + `useInvalidateHealth` helper
- `useYTMusicAuth`: invalidates health query after successful connection so the YT Music badge updates immediately
- `useSpotifyAuth`: invalidates health + shows toast notification on connect
- YT Music frontend: removed client-side `isValidHeaders()` check (broken for alternating-line format), server normalizes and validates instead
- Tests: added `QueryClientProvider` + `ToastProvider` wrappers

## Closes

(none — post-merge fixes)

## Test plan

- [X] `pytest` from `backend/` — 103 passed
- [X] `pnpm test:run` in `frontend/` — 257 passed