### PR TITLE
feat(ui): disable connect controls when already connected

### DIFF
--- a/frontend/src/pages/Connect/Spotify.tsx
+++ b/frontend/src/pages/Connect/Spotify.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Button, FieldError, Input, Label } from '@/components/ui'
 import { useSpotifyAuth } from '@/features/auth/useSpotifyAuth'
 import { useSpotifySetup } from '@/features/auth/useSpotifySetup'
+import { useHealth } from '@/features/auth/useHealth'
 
 export function SpotifyConnect() {
   const { state, errorMessage, connect } = useSpotifyAuth()
@@ -11,8 +12,11 @@ export function SpotifyConnect() {
     errorMessage: setupError,
     save,
   } = useSpotifySetup()
+  const { spotify } = useHealth()
   const [clientId, setClientId] = useState('')
   const [clientSecret, setClientSecret] = useState('')
+
+  const isConnected = spotify === 'connected'
 
   return (
     <section
@@ -26,76 +30,87 @@ export function SpotifyConnect() {
         Conectar Spotify
       </h2>
 
-      {configured === false && (
-        <div className="flex flex-col gap-3 rounded-md border border-gray-200 p-4">
-          <p className="text-sm text-gray-600">
-            Configura tus credenciales de desarrollador de Spotify. Puedes
-            obtenerlas en el{' '}
-            <a
-              href="https://developer.spotify.com/dashboard"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 underline"
-            >
-              Dashboard de Spotify
-            </a>
-            .
-          </p>
-          <div className="flex flex-col gap-1">
-            <Label>Client ID</Label>
-            <Input
-              value={clientId}
-              onChange={(e) => setClientId(e.target.value)}
-              placeholder="Tu Spotify Client ID"
-            />
-          </div>
-          <div className="flex flex-col gap-1">
-            <Label>Client Secret</Label>
-            <Input
-              type="password"
-              value={clientSecret}
-              onChange={(e) => setClientSecret(e.target.value)}
-              placeholder="Tu Spotify Client Secret"
-            />
-          </div>
-          <div>
-            <Button
-              onClick={() => save(clientId, clientSecret)}
-              disabled={!clientId || !clientSecret || setupState === 'saving'}
-              loading={setupState === 'saving'}
-            >
-              Guardar credenciales
-            </Button>
-          </div>
-          {setupState === 'error' && setupError && (
-            <FieldError>{setupError}</FieldError>
+      {isConnected ? (
+        <p className="flex items-center gap-2 text-sm font-medium text-green-700">
+          <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-green-100 text-green-700 text-xs">
+            ✓
+          </span>
+          Conectado a Spotify
+        </p>
+      ) : (
+        <>
+          {configured === false && (
+            <div className="flex flex-col gap-3 rounded-md border border-gray-200 p-4">
+              <p className="text-sm text-gray-600">
+                Configura tus credenciales de desarrollador de Spotify. Puedes
+                obtenerlas en el{' '}
+                <a
+                  href="https://developer.spotify.com/dashboard"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 underline"
+                >
+                  Dashboard de Spotify
+                </a>
+                .
+              </p>
+              <div className="flex flex-col gap-1">
+                <Label>Client ID</Label>
+                <Input
+                  value={clientId}
+                  onChange={(e) => setClientId(e.target.value)}
+                  placeholder="Tu Spotify Client ID"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <Label>Client Secret</Label>
+                <Input
+                  type="password"
+                  value={clientSecret}
+                  onChange={(e) => setClientSecret(e.target.value)}
+                  placeholder="Tu Spotify Client Secret"
+                />
+              </div>
+              <div>
+                <Button
+                  onClick={() => save(clientId, clientSecret)}
+                  disabled={!clientId || !clientSecret || setupState === 'saving'}
+                  loading={setupState === 'saving'}
+                >
+                  Guardar credenciales
+                </Button>
+              </div>
+              {setupState === 'error' && setupError && (
+                <FieldError>{setupError}</FieldError>
+              )}
+            </div>
           )}
-        </div>
-      )}
 
-      <p className="text-sm text-gray-600">
-        Inicia sesión con tu cuenta de Spotify para que podamos leer tus
-        playlists y álbumes guardados. Serás redirigido a Spotify para
-        autorizar el acceso.
-      </p>
-      <div className="flex flex-col gap-2">
-        <div>
-          <Button
-            onClick={connect}
-            disabled={
-              configured !== true ||
-              state === 'starting' ||
-              state === 'success'
-            }
-            loading={state === 'starting'}
-          >
-            Conectar con Spotify
-          </Button>
-        </div>
-        {state === 'error' && errorMessage && (
-          <FieldError>{errorMessage}</FieldError>
-        )}
-      </div>
+          <p className="text-sm text-gray-600">
+            Inicia sesión con tu cuenta de Spotify para que podamos leer tus
+            playlists y álbumes guardados. Serás redirigido a Spotify para
+            autorizar el acceso.
+          </p>
+          <div className="flex flex-col gap-2">
+            <div>
+              <Button
+                onClick={connect}
+                disabled={
+                  configured !== true ||
+                  state === 'starting' ||
+                  state === 'success'
+                }
+                loading={state === 'starting'}
+              >
+                Conectar con Spotify
+              </Button>
+            </div>
+            {state === 'error' && errorMessage && (
+              <FieldError>{errorMessage}</FieldError>
+            )}
+          </div>
+        </>
+      )}
     </section>
   )
 }

--- a/frontend/src/pages/Connect/YTMusic.tsx
+++ b/frontend/src/pages/Connect/YTMusic.tsx
@@ -1,48 +1,64 @@
 import { useState } from 'react';
 import { Button, FieldError, Label, Textarea } from '@/components/ui';
 import { useYTMusicAuth } from '@/features/auth/useYTMusicAuth';
+import { useHealth } from '@/features/auth/useHealth';
 
 export function YTMusicConnect() {
   const [headers, setHeaders] = useState('');
   const { state, errorMessage, connect } = useYTMusicAuth();
+  const { ytmusic } = useHealth();
+
+  const isConnected = ytmusic === 'connected';
 
   return (
     <section aria-labelledby="ytmusic-connect-heading" className="flex flex-col gap-4 p-8">
       <h2 id="ytmusic-connect-heading" className="text-xl font-semibold text-gray-900">
         Conectar YouTube Music
       </h2>
-      <p className="text-sm text-gray-600">
-        Para autenticar con YouTube Music necesitas capturar los headers de tu navegador:
-      </p>
-      <ol className="list-decimal list-inside space-y-1 text-sm text-gray-600">
-        <li>Abre YouTube Music en Chrome o Firefox.</li>
-        <li>Abre las DevTools (F12) y ve a la pestaña <strong>Network</strong>.</li>
-        <li>Recarga la página y filtra las peticiones por <code>browse</code>.</li>
-        <li>Haz clic en cualquier petición a <code>browse</code> y copia los headers de la sección <strong>Request Headers</strong>.</li>
-        <li>Pega los headers en el campo de abajo y pulsa «Conectar».</li>
-      </ol>
-      <div className="flex flex-col gap-1">
-        <Label htmlFor="ytmusic-headers">Headers del navegador</Label>
-        <Textarea
-          id="ytmusic-headers"
-          value={headers}
-          onChange={(e) => setHeaders(e.target.value)}
-          rows={8}
-          placeholder="Pega aquí los headers copiados de DevTools..."
-        />
-      </div>
-      <div className="flex flex-col gap-2">
-        <div>
-          <Button
-            onClick={() => connect(headers)}
-            disabled={headers.trim().length === 0 || state === 'submitting' || state === 'success'}
-            loading={state === 'submitting'}
-          >
-            Conectar con YouTube Music
-          </Button>
-        </div>
-        {errorMessage && <FieldError>{errorMessage}</FieldError>}
-      </div>
+
+      {isConnected ? (
+        <p className="flex items-center gap-2 text-sm font-medium text-green-700">
+          <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-green-100 text-green-700 text-xs">
+            ✓
+          </span>
+          Conectado a YouTube Music
+        </p>
+      ) : (
+        <>
+          <p className="text-sm text-gray-600">
+            Para autenticar con YouTube Music necesitas capturar los headers de tu navegador:
+          </p>
+          <ol className="list-decimal list-inside space-y-1 text-sm text-gray-600">
+            <li>Abre YouTube Music en Chrome o Firefox.</li>
+            <li>Abre las DevTools (F12) y ve a la pestaña <strong>Network</strong>.</li>
+            <li>Recarga la página y filtra las peticiones por <code>browse</code>.</li>
+            <li>Haz clic en cualquier petición a <code>browse</code> y copia los headers de la sección <strong>Request Headers</strong>.</li>
+            <li>Pega los headers en el campo de abajo y pulsa «Conectar».</li>
+          </ol>
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="ytmusic-headers">Headers del navegador</Label>
+            <Textarea
+              id="ytmusic-headers"
+              value={headers}
+              onChange={(e) => setHeaders(e.target.value)}
+              rows={8}
+              placeholder="Pega aquí los headers copiados de DevTools..."
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <div>
+              <Button
+                onClick={() => connect(headers)}
+                disabled={headers.trim().length === 0 || state === 'submitting' || state === 'success'}
+                loading={state === 'submitting'}
+              >
+                Conectar con YouTube Music
+              </Button>
+            </div>
+            {errorMessage && <FieldError>{errorMessage}</FieldError>}
+          </div>
+        </>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
﻿## Summary

When Spotify or YouTube Music is already connected, the connect forms (credentials, headers textarea, connect buttons) are hidden. Instead, a green checkmark with "Conectado a Spotify" / "Conectado a YouTube Music" is shown.

The connection state comes from `useHealth` which now has `staleTime: 0`.

## Test plan

- [X] `pnpm test:run` — 257 passed
- [X] `pnpm lint` — clean
- [X] `pnpm build` — OK
