### PR TITLE
feat(ui): dark mode, purple theme, search bar, disconnect buttons

### DIFF
--- a/backend/src/spotify_to_ytmusic/api/routes/auth.py
+++ b/backend/src/spotify_to_ytmusic/api/routes/auth.py
@@ -98,6 +98,24 @@ async def auth_ytmusic(body: dict) -> OkResponse | ErrorResponse:
     return OkResponse(ok=True)
 
 
+@router.delete("/auth/ytmusic")
+async def disconnect_ytmusic() -> OkResponse:
+    import os
+    if os.path.isfile(BROWSER_AUTH_FILE):
+        os.remove(BROWSER_AUTH_FILE)
+    return OkResponse(ok=True)
+
+
+@router.delete("/auth/spotify")
+async def disconnect_spotify() -> OkResponse:
+    import os
+    if os.path.isfile(SPOTIFY_TOKEN_CACHE_FILE):
+        os.remove(SPOTIFY_TOKEN_CACHE_FILE)
+    if os.path.isfile(SPOTIFY_CREDENTIALS_FILE):
+        os.remove(SPOTIFY_CREDENTIALS_FILE)
+    return OkResponse(ok=True)
+
+
 # ---- Spotify credentials persistence (desktop app) ----
 
 import json

--- a/backend/src/spotify_to_ytmusic/api/server.py
+++ b/backend/src/spotify_to_ytmusic/api/server.py
@@ -1,4 +1,5 @@
 """Entrypoint: python -m spotify_to_ytmusic.api.server"""
+import logging
 import sys
 
 from dotenv import load_dotenv
@@ -8,6 +9,8 @@ load_dotenv()
 from spotify_to_ytmusic.api.routes.auth import load_persisted_credentials
 
 load_persisted_credentials()
+
+logging.getLogger("spotipy.client").setLevel(logging.CRITICAL)
 
 import uvicorn
 

--- a/backend/src/spotify_to_ytmusic/api/sidecar_server.py
+++ b/backend/src/spotify_to_ytmusic/api/sidecar_server.py
@@ -3,6 +3,7 @@
 Reads the port from argv[1] (0 = random), starts uvicorn, and prints
 ``SERVER_LISTENING port=<n>`` to stdout so the Tauri host can discover it.
 """
+import logging
 import os
 import socket
 import sys
@@ -14,6 +15,8 @@ load_dotenv()
 from spotify_to_ytmusic.api.routes.auth import load_persisted_credentials
 
 load_persisted_credentials()
+
+logging.getLogger("spotipy.client").setLevel(logging.CRITICAL)
 
 import uvicorn
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="es">
+<html lang="es" class="dark">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -13,8 +13,8 @@ export function Header() {
   const { spotify, ytmusic } = useHealth();
 
   return (
-    <header className="flex h-14 items-center justify-between border-b bg-white px-4 gap-2 sm:gap-4">
-      <h1 className="text-lg sm:text-xl font-bold text-gray-900 shrink-0">Spotify → YT Music</h1>
+    <header className="flex h-14 items-center justify-between border-b border-gray-700 bg-gray-900 px-4 gap-2 sm:gap-4">
+      <h1 className="text-lg sm:text-xl font-bold text-gray-100 shrink-0">Spotify → YT Music</h1>
       <nav aria-label="Navegación principal" className="flex gap-1 overflow-x-auto scrollbar-none whitespace-nowrap">
         {NAV_ITEMS.map((item) => (
           <NavLink
@@ -24,8 +24,8 @@ export function Header() {
               [
                 'px-3 py-1.5 rounded-md text-sm font-medium transition-colors shrink-0',
                 isActive
-                  ? 'bg-gray-100 text-gray-900'
-                  : 'text-gray-500 hover:text-gray-900 hover:bg-gray-50',
+                  ? 'bg-gray-700 text-gray-100'
+                  : 'text-gray-400 hover:text-gray-100 hover:bg-gray-800',
               ].join(' ')
             }
           >

--- a/frontend/src/components/ui/Button.test.tsx
+++ b/frontend/src/components/ui/Button.test.tsx
@@ -11,13 +11,13 @@ describe('Button', () => {
   it('renders primary variant', () => {
     render(<Button variant="primary">Primary</Button>)
     const button = screen.getByRole('button')
-    expect(button).toHaveClass('bg-blue-600')
+    expect(button).toHaveClass('bg-primary-600')
   })
 
   it('renders secondary variant', () => {
     render(<Button variant="secondary">Secondary</Button>)
     const button = screen.getByRole('button')
-    expect(button).toHaveClass('bg-gray-200')
+    expect(button).toHaveClass('bg-gray-700')
   })
 
   it('renders ghost variant', () => {

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -8,9 +8,9 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const variantStyles = {
-  primary: 'bg-blue-600 text-white hover:bg-blue-700 focus-visible:ring-blue-600',
-  secondary: 'bg-gray-200 text-gray-900 hover:bg-gray-300 focus-visible:ring-gray-400',
-  ghost: 'bg-transparent text-gray-700 hover:bg-gray-100 focus-visible:ring-gray-400',
+  primary: 'bg-primary-600 text-white hover:bg-primary-700 focus-visible:ring-primary-600',
+  secondary: 'bg-gray-700 text-gray-200 hover:bg-gray-600 focus-visible:ring-gray-400',
+  ghost: 'bg-transparent text-gray-300 hover:bg-gray-800 focus-visible:ring-gray-400',
 }
 
 const sizeStyles = {

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -16,12 +16,12 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         aria-invalid={error}
         aria-describedby={error ? `${id}-error` : undefined}
         className={[
-          'flex h-10 w-full rounded-md border bg-white px-3 py-2 text-sm transition-colors',
-          'placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+          'flex h-10 w-full rounded-md border bg-gray-800 px-3 py-2 text-sm transition-colors text-gray-100',
+          'placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900',
           'disabled:cursor-not-allowed disabled:opacity-50',
           error
             ? 'border-red-500 focus-visible:ring-red-500'
-            : 'border-gray-300 focus-visible:ring-blue-600',
+            : 'border-gray-600 focus-visible:ring-primary-600',
           className,
         ].join(' ')}
         {...props}

--- a/frontend/src/components/ui/Label.tsx
+++ b/frontend/src/components/ui/Label.tsx
@@ -11,7 +11,7 @@ export function Label({ children, id: propsId, className = '', ...props }: Label
   return (
     <label
       htmlFor={id}
-      className={['text-sm font-medium text-gray-700', className].join(' ')}
+      className={['text-sm font-medium text-gray-300', className].join(' ')}
       {...props}
     >
       {children}

--- a/frontend/src/components/ui/Textarea.tsx
+++ b/frontend/src/components/ui/Textarea.tsx
@@ -16,12 +16,12 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         aria-invalid={error}
         aria-describedby={error ? `${id}-error` : undefined}
         className={[
-          'flex min-h-[80px] w-full rounded-md border bg-white px-3 py-2 text-sm transition-colors',
-          'placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+          'flex min-h-[80px] w-full rounded-md border bg-gray-800 px-3 py-2 text-sm transition-colors text-gray-100',
+          'placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900',
           'disabled:cursor-not-allowed disabled:opacity-50',
           error
             ? 'border-red-500 focus-visible:ring-red-500'
-            : 'border-gray-300 focus-visible:ring-blue-600',
+            : 'border-gray-600 focus-visible:ring-primary-600',
           className,
         ].join(' ')}
         {...props}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply bg-gray-900 text-gray-100;
+}

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -101,4 +101,8 @@ export const http = {
       { timeoutMs },
     )
   },
+  delete<T>(path: string, options?: RequestOptions): Promise<T> {
+    const { init, timeoutMs } = splitOptions(options)
+    return request<T>(path, { ...init, method: 'DELETE' }, { timeoutMs })
+  },
 }

--- a/frontend/src/pages/Connect/Spotify.tsx
+++ b/frontend/src/pages/Connect/Spotify.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { Button, FieldError, Input, Label } from '@/components/ui'
+import { http } from '@/lib/http'
 import { useSpotifyAuth } from '@/features/auth/useSpotifyAuth'
 import { useSpotifySetup } from '@/features/auth/useSpotifySetup'
-import { useHealth } from '@/features/auth/useHealth'
+import { useHealth, useInvalidateHealth } from '@/features/auth/useHealth'
 
 export function SpotifyConnect() {
   const { state, errorMessage, connect } = useSpotifyAuth()
@@ -13,10 +14,15 @@ export function SpotifyConnect() {
     save,
   } = useSpotifySetup()
   const { spotify } = useHealth()
+  const invalidateHealth = useInvalidateHealth()
   const [clientId, setClientId] = useState('')
   const [clientSecret, setClientSecret] = useState('')
 
   const isConnected = spotify === 'connected'
+
+  const disconnect = useCallback(() => {
+    http.delete('/auth/spotify').then(() => invalidateHealth());
+  }, [invalidateHealth]);
 
   return (
     <section
@@ -31,12 +37,19 @@ export function SpotifyConnect() {
       </h2>
 
       {isConnected ? (
-        <p className="flex items-center gap-2 text-sm font-medium text-green-700">
-          <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-green-100 text-green-700 text-xs">
-            ✓
-          </span>
-          Conectado a Spotify
-        </p>
+        <div className="flex flex-col gap-2">
+          <p className="flex items-center gap-2 text-sm font-medium text-green-700">
+            <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-green-100 text-green-700 text-xs">
+              ✓
+            </span>
+            Conectado a Spotify
+          </p>
+          <div>
+            <Button onClick={disconnect} className="bg-red-600 hover:bg-red-700">
+              Desconectar
+            </Button>
+          </div>
+        </div>
       ) : (
         <>
           {configured === false && (

--- a/frontend/src/pages/Connect/YTMusic.tsx
+++ b/frontend/src/pages/Connect/YTMusic.tsx
@@ -1,14 +1,21 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Button, FieldError, Label, Textarea } from '@/components/ui';
+import { http } from '@/lib/http';
 import { useYTMusicAuth } from '@/features/auth/useYTMusicAuth';
 import { useHealth } from '@/features/auth/useHealth';
+import { useInvalidateHealth } from '@/features/auth/useHealth';
 
 export function YTMusicConnect() {
   const [headers, setHeaders] = useState('');
   const { state, errorMessage, connect } = useYTMusicAuth();
   const { ytmusic } = useHealth();
+  const invalidateHealth = useInvalidateHealth();
 
   const isConnected = ytmusic === 'connected';
+
+  const disconnect = useCallback(() => {
+    http.delete('/auth/ytmusic').then(() => invalidateHealth());
+  }, [invalidateHealth]);
 
   return (
     <section aria-labelledby="ytmusic-connect-heading" className="flex flex-col gap-4 p-8">
@@ -17,12 +24,19 @@ export function YTMusicConnect() {
       </h2>
 
       {isConnected ? (
-        <p className="flex items-center gap-2 text-sm font-medium text-green-700">
-          <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-green-100 text-green-700 text-xs">
-            ✓
-          </span>
-          Conectado a YouTube Music
-        </p>
+        <div className="flex flex-col gap-2">
+          <p className="flex items-center gap-2 text-sm font-medium text-green-700">
+            <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-green-100 text-green-700 text-xs">
+              ✓
+            </span>
+            Conectado a YouTube Music
+          </p>
+          <div>
+            <Button onClick={disconnect} className="bg-red-600 hover:bg-red-700">
+              Desconectar
+            </Button>
+          </div>
+        </div>
       ) : (
         <>
           <p className="text-sm text-gray-600">

--- a/frontend/src/pages/Library/Albums.tsx
+++ b/frontend/src/pages/Library/Albums.tsx
@@ -1,4 +1,5 @@
-import { Button, EmptyState, List, ListItem, ListItemTrailing, Skeleton } from '@/components/ui';
+import { useState } from 'react';
+import { Button, EmptyState, Input, List, ListItem, ListItemTrailing, Skeleton } from '@/components/ui';
 import { useAlbums } from '@/features/library/useAlbums';
 
 function AlbumSkeletons() {
@@ -20,13 +21,14 @@ export interface AlbumsProps {
 
 export function Albums({ selectedIds = new Set(), onToggle, onToggleAll, selectionState = 'none' }: AlbumsProps) {
   const { data, isLoading, isError, refetch } = useAlbums();
+  const [search, setSearch] = useState('');
 
   if (isLoading) return <AlbumSkeletons />;
 
   if (isError) {
     return (
       <div className="flex flex-col items-center gap-3 p-8 text-center">
-        <p className="text-sm text-red-600">No se pudieron cargar los álbumes.</p>
+        <p className="text-sm text-red-400">No se pudieron cargar los álbumes.</p>
         <Button onClick={() => refetch()}>Reintentar</Button>
       </div>
     );
@@ -41,10 +43,22 @@ export function Albums({ selectedIds = new Set(), onToggle, onToggleAll, selecti
     );
   }
 
+  const lower = search.toLowerCase();
+  const filtered = search
+    ? data.filter((a) => a.name.toLowerCase().includes(lower) || a.artist.toLowerCase().includes(lower))
+    : data;
+
   return (
     <div>
+      <div className="px-3 py-2">
+        <Input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Buscar álbumes..."
+        />
+      </div>
       {onToggleAll && (
-        <div className="flex items-center gap-3 px-4 py-2 border-b border-gray-200 bg-gray-50">
+        <div className="flex items-center gap-3 px-4 py-2 border-b border-gray-700 bg-gray-800">
           <input
             type="checkbox"
             aria-label="Seleccionar todos los álbumes"
@@ -53,31 +67,35 @@ export function Albums({ selectedIds = new Set(), onToggle, onToggleAll, selecti
               if (el) el.indeterminate = selectionState === 'some';
             }}
             onChange={onToggleAll}
-            className="h-4 w-4 rounded border-gray-300 text-blue-600"
+            className="h-4 w-4 rounded border-gray-500 text-primary-600"
           />
-          <span className="text-xs text-gray-500">Seleccionar todos</span>
+          <span className="text-xs text-gray-400">Seleccionar todos</span>
         </div>
       )}
-      <List selectedIds={[...selectedIds]} onSelect={onToggle}>
-        {data.map((album) => (
-          <ListItem key={album.spotifyId} id={album.spotifyId}>
-            {onToggle && (
-              <input
-                type="checkbox"
-                aria-label={`Seleccionar ${album.name}`}
-                checked={selectedIds.has(album.spotifyId)}
-                onChange={() => onToggle(album.spotifyId)}
-                className="h-4 w-4 rounded border-gray-300 text-blue-600"
-                onClick={(e) => e.stopPropagation()}
-              />
-            )}
-            <span className="flex-1 text-sm font-medium text-gray-900">{album.name}</span>
-            <ListItemTrailing>
-              <span className="text-xs text-gray-500">{album.artist}</span>
-            </ListItemTrailing>
-          </ListItem>
-        ))}
-      </List>
+      {filtered.length === 0 ? (
+        <p className="p-4 text-sm text-gray-400">Sin resultados.</p>
+      ) : (
+        <List selectedIds={[...selectedIds]} onSelect={onToggle}>
+          {filtered.map((album) => (
+            <ListItem key={album.spotifyId} id={album.spotifyId}>
+              {onToggle && (
+                <input
+                  type="checkbox"
+                  aria-label={`Seleccionar ${album.name}`}
+                  checked={selectedIds.has(album.spotifyId)}
+                  onChange={() => onToggle(album.spotifyId)}
+                  className="h-4 w-4 rounded border-gray-500 text-primary-600"
+                  onClick={(e) => e.stopPropagation()}
+                />
+              )}
+              <span className="flex-1 text-sm font-medium text-gray-200">{album.name}</span>
+              <ListItemTrailing>
+                <span className="text-xs text-gray-400">{album.artist}</span>
+              </ListItemTrailing>
+            </ListItem>
+          ))}
+        </List>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/Library/Playlists.tsx
+++ b/frontend/src/pages/Library/Playlists.tsx
@@ -1,4 +1,5 @@
-import { Button, EmptyState, List, ListItem, ListItemTrailing, Skeleton } from '@/components/ui';
+import { useState } from 'react';
+import { Button, EmptyState, Input, List, ListItem, ListItemTrailing, Skeleton } from '@/components/ui';
 import { usePlaylists } from '@/features/library/usePlaylists';
 import type { SelectionState } from '@/features/library/useSelection';
 
@@ -26,13 +27,14 @@ export function Playlists({
   selectionState = 'none',
 }: PlaylistsProps) {
   const { data, isLoading, isError, refetch } = usePlaylists();
+  const [search, setSearch] = useState('');
 
   if (isLoading) return <PlaylistSkeletons />;
 
   if (isError) {
     return (
       <div className="flex flex-col items-center gap-3 p-8 text-center">
-        <p className="text-sm text-red-600">No se pudieron cargar las playlists.</p>
+        <p className="text-sm text-red-400">No se pudieron cargar las playlists.</p>
         <Button onClick={() => refetch()}>Reintentar</Button>
       </div>
     );
@@ -47,10 +49,22 @@ export function Playlists({
     );
   }
 
+  const lower = search.toLowerCase();
+  const filtered = search
+    ? data.filter((p) => p.name.toLowerCase().includes(lower))
+    : data;
+
   return (
     <div>
+      <div className="px-3 py-2">
+        <Input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Buscar playlists..."
+        />
+      </div>
       {onToggleAll && (
-        <div className="flex items-center gap-3 px-4 py-2 border-b border-gray-200 bg-gray-50">
+        <div className="flex items-center gap-3 px-4 py-2 border-b border-gray-700 bg-gray-800">
           <input
             type="checkbox"
             aria-label="Seleccionar todas las playlists"
@@ -59,31 +73,35 @@ export function Playlists({
               if (el) el.indeterminate = selectionState === 'some';
             }}
             onChange={onToggleAll}
-            className="h-4 w-4 rounded border-gray-300 text-blue-600"
+            className="h-4 w-4 rounded border-gray-500 text-primary-600"
           />
-          <span className="text-xs text-gray-500">Seleccionar todas</span>
+          <span className="text-xs text-gray-400">Seleccionar todas</span>
         </div>
       )}
-      <List selectedIds={[...selectedIds]} onSelect={onToggle}>
-        {data.map((playlist) => (
-          <ListItem key={playlist.id} id={playlist.id}>
-            {onToggle && (
-              <input
-                type="checkbox"
-                aria-label={`Seleccionar ${playlist.name}`}
-                checked={selectedIds.has(playlist.id)}
-                onChange={() => onToggle(playlist.id)}
-                className="h-4 w-4 rounded border-gray-300 text-blue-600"
-                onClick={(e) => e.stopPropagation()}
-              />
-            )}
-            <span className="flex-1 text-sm font-medium text-gray-900">{playlist.name}</span>
-            <ListItemTrailing>
-              <span className="text-xs text-gray-500">{playlist.trackCount} canciones</span>
-            </ListItemTrailing>
-          </ListItem>
-        ))}
-      </List>
+      {filtered.length === 0 ? (
+        <p className="p-4 text-sm text-gray-400">Sin resultados.</p>
+      ) : (
+        <List selectedIds={[...selectedIds]} onSelect={onToggle}>
+          {filtered.map((playlist) => (
+            <ListItem key={playlist.id} id={playlist.id}>
+              {onToggle && (
+                <input
+                  type="checkbox"
+                  aria-label={`Seleccionar ${playlist.name}`}
+                  checked={selectedIds.has(playlist.id)}
+                  onChange={() => onToggle(playlist.id)}
+                  className="h-4 w-4 rounded border-gray-500 text-primary-600"
+                  onClick={(e) => e.stopPropagation()}
+                />
+              )}
+              <span className="flex-1 text-sm font-medium text-gray-200">{playlist.name}</span>
+              <ListItemTrailing>
+                <span className="text-xs text-gray-400">{playlist.trackCount} canciones</span>
+              </ListItemTrailing>
+            </ListItem>
+          ))}
+        </List>
+      )}
     </div>
   );
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,8 +1,24 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
+  darkMode: 'class',
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: {
+          50: '#faf5ff',
+          100: '#f3e8ff',
+          200: '#e9d5ff',
+          300: '#d8b4fe',
+          400: '#c084fc',
+          500: '#a855f7',
+          600: '#9333ea',
+          700: '#7e22ce',
+          800: '#6b21a8',
+          900: '#581c87',
+        },
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
﻿## Summary

- **Dark mode**: forced via `class="dark"` on html, dark backgrounds/text throughout
- **Purple theme**: primary color changed from blue to purple (Tailwind `primary` palette)
- **Search bar**: filters playlists by name and albums by name/artist in Library
- **Disconnect buttons**: DELETE endpoints for Spotify and YT Music auth, UI buttons to force reconnection
- Dark mode colors updated for: Button, Input, Textarea, Label, Header, nav links, checkboxes
- `http.ts`: added `delete()` method

## Test plan

- [X] `pytest` — 103 passed
- [X] `pnpm test:run` — 257 passed
- [X] `pnpm lint` — clean
- [X] `pnpm build` — OK
