### PR TITLE
fix(ui): full dark mode consistency, navigation blocker, docs update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,180 +5,118 @@ live in `README.md` and `backend/README.md`.
 
 ## What this is
 
-CLI that migrates a Spotify library (playlists + saved albums) to YouTube
-Music. Monorepo:
+Desktop app + CLI that migrates a Spotify library (playlists + saved albums)
+to YouTube Music. Monorepo:
 
-- **`backend/`** — Python package and CLI. Production-ready for the CLI
-  flow; emits typed `MigrationEvent`s ready for an HTTP/WS transport.
-- **`frontend/`** — Vite/React 19 + TanStack Query + react-router-dom 7.
-  Full UI built page by page (Connect, Library, Migrate, Reports). Talks
-  to the backend through a `*/api/...` contract that **only MSW serves
-  today** — there is no live HTTP backend yet.
-- **`backend/src/spotify_to_ytmusic/api/`** — empty placeholder reserved
-  for the FastAPI server (issues #67–#70 will fill it in).
-
-**The integration gap is the next big piece of work.** Until then:
-
-- CLI is the only end-to-end working flow (`python backend/main.py …`).
-- Frontend "works" against MSW mocks: it renders, navigates, validates
-  forms, exercises hooks/tests — but Connect doesn't actually OAuth,
-  Migrate doesn't actually run a job, and Reports list/detail are
-  fixtures, not files on disk.
-- **Don't bootstrap the FastAPI server (`api/`) unless the task explicitly
-  asks for it.** Same for new top-level frontend features.
+- **`backend/`** — Python package with CLI, migration logic, and a FastAPI
+  server (`api/`). Emits typed `MigrationEvent`s ready for HTTP/WS transport.
+- **`frontend/`** — Vite/React 19 + TanStack Query + react-router-dom 7 + Tauri 2.
+  Full UI (Connect, Library, Migrate, Reports). Talks to the backend via
+  Vite proxy in dev mode, or via sidecar IPC in production Tauri builds.
+  MSW mocks available for offline frontend development.
+- **Desktop app** — Tauri 2 wraps the frontend + a PyInstaller-compiled sidecar
+  binary. See [`PACKAGING.md`](PACKAGING.md).
 
 ## Where to run things
 
 - Working directory for commands is the repo root unless noted.
-- The CLI resolves `data/` relative to the current working directory
-  ([config.py](backend/src/spotify_to_ytmusic/core/config.py)). Run scripts
-  from `backend/` or set `SPOTIFY_TO_YTMUSIC_DATA_DIR` so it finds
-  `browser.json`, `.cache`, and `track_cache.json`.
-- Editable install lives in the user site-packages, not a venv. Imports
-  resolve via `PYTHONPATH=backend/src` for ad-hoc scripts.
+- The CLI resolves `data/` relative to cwd. Run from `backend/` or set
+  `SPOTIFY_TO_YTMUSIC_DATA_DIR`.
+- Imports resolve via `PYTHONPATH=backend/src` for ad-hoc scripts.
 
 ## Common commands
 
 ```bash
-# Run the migrator
-python backend/main.py --playlists      # interactive multi-select
-python backend/main.py --all            # everything, no prompts
-python backend/main.py --albums         # saved albums only
+# --- Backend ---
+python backend/main.py --playlists   # interactive multi-select
+python backend/main.py --all         # everything, no prompts
+python backend/main.py --albums      # saved albums only
 
-# Re-auth YT Music (when browser.json expires)
+# Start API server (for frontend dev)
+python -m spotify_to_ytmusic.api.server 8000
+
+# Re-auth YT Music
 cd backend && python setup_ytmusic.py
-```
 
-`pytest` and `ruff` are listed in `[project.optional-dependencies].dev`.
-There is no CI yet, but new code is expected to ship with tests — see the
-Definition of Done below.
+# Backend tests
+cd backend && pytest
+
+# --- Frontend ---
+cd frontend && pnpm install
+pnpm dev                 # Vite dev server on :5173
+pnpm test:run            # Vitest
+pnpm lint && pnpm build
+
+# --- Desktop (Tauri) ---
+cd frontend && pnpm tauri dev    # dev mode (needs backend on :8000)
+pnpm tauri build                 # production bundle (needs sidecar + keypair)
+```
 
 ## Architecture in one paragraph
 
 `Migrator` ([core/migrator.py](backend/src/spotify_to_ytmusic/core/migrator.py))
-is the orchestrator and emits typed events via an `on_event` callback. The CLI
+is the orchestrator — emits typed events via an `on_event` callback. The CLI
 ([cli/__init__.py](backend/src/spotify_to_ytmusic/cli/__init__.py)) registers
-`_print_event` as the callback to render progress. **Don't `print()` from
-core/** — keep presentation in the CLI layer so a future WebSocket transport
-can reuse the same events.
+`_print_event`; the API server ([routes/migrate.py](backend/src/spotify_to_ytmusic/api/routes/migrate.py))
+pushes events into an asyncio queue for WebSocket streaming. **Don't `print()`
+from core/** — emit a `MigrationEvent`.
 
 `SpotifyClient` separates discovery (`list_playlist_summaries`, fast, no
 tracks) from track loading (`load_playlist_by_id`, slow, lazy). `YTMusicClient`
 wraps `ytmusicapi` with retry/backoff. `TrackCache` persists
-`spotify_id → videoId | NOT_FOUND` so retried migrations skip the slow YT
-Music searches.
+`spotify_id → videoId | NOT_FOUND`.
 
 ## Non-obvious gotchas
 
-These will bite you if you don't know them. They're all the result of fixes
-in git history, so check the relevant commit before "improving" any of this.
-
 - **Spotify API shape changed in 2025-2026.** Playlist items use `"item"`
   for the track object (the legacy `"track"` key is now a boolean). Playlist
-  summaries use `items.total` for the track count, not `tracks.total`. See
-  [spotify_client.py](backend/src/spotify_to_ytmusic/core/spotify_client.py).
-- **`ytmusicapi.add_playlist_items` rejects the entire chunk if any
-  videoId is a duplicate.** Always pass `duplicates=True`. Spotify allows
-  repeated tracks and YT search can collapse distinct tracks to the same
-  videoId.
+  summaries use `items.total` for the track count.
+- **`ytmusicapi.add_playlist_items` rejects duplicates.** Always pass
+  `duplicates=True`.
 - **YT Music throttles `add_playlist_items` by returning empty bodies**,
-  surfacing as `JSONDecodeError`. The fix is exponential backoff in
-  [ytmusic_client.py `_add_chunk_with_retry`](backend/src/spotify_to_ytmusic/core/ytmusic_client.py).
-  Don't catch and silently ignore — silent drops cost the user data.
-- **`YTMusicClient` distinguishes transient from fatal errors.** Public
-  methods can raise `YTMusicTransientError` (network/throttle, retries
-  already exhausted) or `YTMusicFatalError` (auth, 4xx, anything not
-  classified as transient). Never write `except Exception: return None`
-  in this module — use `_classify_exception` so fatals propagate
-  immediately instead of burning the retry budget. The `Migrator`
-  catches `YTMusicFatalError` per playlist/album and records the reason
-  in `MigrationReport.error` so the user sees why the item failed.
-  `YTMusicAuthError` is reserved for the construction-time check in
-  `_verify_auth`.
-- **403s from `playlist_tracks` are normal** for playlists the user doesn't
-  fully own (e.g. some collaborative or algorithmic ones). `load_playlist_by_id`
-  returns `None` in that case; the migrator just skips the playlist.
-- **`spotipy.client` logs are silenced to CRITICAL** in
-  [cli/__init__.py](backend/src/spotify_to_ytmusic/cli/__init__.py) to hide
-  the 403 spam above. If you're debugging Spotify issues, raise that
-  temporarily — but don't ship it raised, the spam is overwhelming.
+  surfacing as `JSONDecodeError`. Fixed with exponential backoff in
+  `_add_chunk_with_retry`. Don't catch and silently ignore.
+- **`YTMusicClient` distinguishes transient vs fatal errors.** Use
+  `_classify_exception` — fatals propagate immediately, transients retry.
+  `YTMusicAuthError` is construction-time only (in `_verify_auth`).
+- **403s from `playlist_tracks` are normal** for collaborative/algorithmic
+  playlists. `load_playlist_by_id` returns `None`; migrator skips them.
+  Logs are silenced to CRITICAL in both CLI and API server.
 - **Tracks with empty `spotify_id`** (rare local files) bypass the cache.
-  Don't assume every Track has a usable id.
-- **The frontend uses pnpm, not npm.** `pnpm-lock.yaml` is the source of
-  truth. npm 11.12.1 crashes with `Cannot read properties of null (reading
-  'matches')` (arborist bug) when installing some deps like `msw`. Use
-  `pnpm add` / `pnpm install` from `frontend/`.
+- **The frontend uses pnpm, not npm.** `pnpm-lock.yaml` is the source of truth.
 - **MSW path patterns must be `*/api/...`, not `/api/...`.** Relative paths
-  match in the browser worker but not in Vitest's Node environment, so
-  handler tests silently fall through to `onUnhandledRequest: 'error'`. See
-  [handlers.ts](frontend/src/test/msw/handlers.ts).
-- **WebSocket reconnection only fires on abnormal closes.** `WsConnection.onclose`
-  short-circuits to `closed` (no reconnect) when `ev.wasClean`, `ev.code === 1000`
-  or `ev.code === 1005`. The MSW handler closes the WS cleanly after streaming
-  the fixture batch — without this guard the migrate page enters an infinite
-  reopen loop. See [ws.ts](frontend/src/lib/ws.ts) and the regression test
-  `does not reconnect when the server closes the stream cleanly` in
-  [useMigrationEvents.test.tsx](frontend/src/hooks/useMigrationEvents.test.tsx).
-- **Selection lives in `SelectionContext`, not in page-local state.** Each
-  page used to call `useSelection` independently, which silently reset the
-  user's choices when navigating Library → Migrate. Read/write through
-  [`useSelectionContext`](frontend/src/contexts/useSelectionContext.ts);
-  don't introduce new local `useState(new Set())` for picked playlists/albums.
-- **Routing is real (`react-router-dom` v7).** Use `<Link>`/`<NavLink>` and
-  `useNavigate` — don't reintroduce a `section` enum or imperative
-  `setSection` calls. Deep links like `/reports/:id` must keep working on
-  refresh.
-- **Per-page focus management uses `useAutoFocusHeading`.** The old global
-  `useEffect` in `App.tsx` that searched for any `h2/h3` was removed.
-  Each page declares its own heading `ref` and calls the hook on mount.
-  Don't reintroduce a cross-page focus side-effect.
-- **`http.ts` enforces a 15 s default timeout** via `AbortSignal.timeout`.
-  Override per call with `http.get(path, { timeoutMs })`. A timed-out
-  request rejects with a `DOMException` whose `name` is `TimeoutError`
-  (or `AbortError` if the caller aborted). Don't wrap `fetch` directly
-  from feature code — go through `http`.
-
-## Style and conventions
-
-- Spanish in user-facing CLI strings (e.g. the questionary prompt) is
-  intentional — match the existing tone, don't translate to English.
-- Conventional Commits with scope: `feat(cli)`, `fix(ytmusic)`,
-  `feat(cache)`, `feat(migrator)`, `docs`, `chore(config)`. Recent history
-  is consistent; new commits should follow.
-- Don't add comments that just restate what the code does. The existing
-  comments mark non-obvious behavior (the gotchas above) — that's the bar.
+  match in browser worker but not in Vitest's Node environment.
+- **WebSocket reconnection only fires on abnormal closes.** Clean close codes
+  (1000/1005) are considered final.
+- **Selection lives in `SelectionContext`.** Don't introduce page-local
+  `useState(new Set())` for picked items.
+- **Routing is real (`react-router-dom` v7).** Use `<NavLink>` and `useNavigate`.
+- **Per-page focus uses `useAutoFocusHeading`.** No global heading search.
+- **`http.ts` enforces 15 s timeout** via `AbortSignal.timeout`. Go through
+  `http`, not raw `fetch`.
+- **Spotify credentials persist to `DATA_DIR/spotify_credentials.json`.**
+  User sets them via the Connect page UI. `.env` takes precedence if present.
+- **`SPOTIFY_REDIRECT_URI` in `.env` is CLI-only** (`:8888`). The API server
+  always uses its own callback URL (`:5173` in dev, `:8000` in prod).
+- **Dark mode is forced** (`class="dark"` on `<html>`). Primary color is purple
+  (`primary-*` Tailwind palette). Don't introduce `blue-*` or light `gray-*`
+  classes.
+- **Migration page blocks navigation** while a job is running. Nav links are
+  disabled and a confirmation dialog appears on exit attempts.
 
 ## Definition of Done
 
-A task is **only done** when **all** of the following hold. Read
-[CONTRIBUTING.md](CONTRIBUTING.md) for the full version — this is the short
-form so it's always in your context:
-
-1. **All acceptance criteria met.** If the task came from an issue, every
-   checkbox in the issue is satisfied. If from a verbal request, restate
-   what "done" means and verify each point.
-2. **SOLID + clean code.** Single responsibility per module/class, small
-   focused functions, meaningful names, no dead code, no premature
-   abstraction. When in doubt, prefer the simplest thing that works over
-   a generic framework.
-3. **Tests exist and pass.** New behavior has unit tests; bug fixes get a
-   regression test that fails before the fix and passes after. Run
-   `pytest` from `backend/` and confirm green before declaring done.
-   Frontend tests (Vitest) when/where the frontend gets behavior worth
-   testing.
-4. **Architectural fit.** Respect the existing layering:
-   - No `print()` from `core/` — emit a `MigrationEvent` and let the CLI
-     layer render it.
-   - Reuse `SpotifyClient` / `YTMusicClient` / `TrackCache` instead of
-     calling `spotipy` / `ytmusicapi` directly from new code.
-   - Tunables go in [config.py](backend/src/spotify_to_ytmusic/core/config.py),
-     not hardcoded.
-   - Don't bootstrap the FastAPI server (`api/`) or the frontend unless
-     the task explicitly asks for it.
-
-If any of these can't be met for a real reason, **say so explicitly in
-the PR/handoff** rather than silently skipping. "No tests because X" is
-acceptable; "done" without tests when tests were possible is not.
+1. **All acceptance criteria met.**
+2. **SOLID + clean code.** Small focused functions, meaningful names,
+   no dead code, no premature abstraction.
+3. **Tests exist and pass.** `pytest` from `backend/`, `pnpm test:run` from
+   `frontend/`.
+4. **Architectural fit:**
+   - No `print()` from `core/` — emit `MigrationEvent`.
+   - Reuse `SpotifyClient` / `YTMusicClient` / `TrackCache`.
+   - Tunables in `config.py`.
+   - Frontend: selection via `SelectionContext`, nav via react-router-dom,
+     focus via `useAutoFocusHeading`, fetch via `lib/http.ts`.
 
 ## What lives where
 
@@ -189,7 +127,7 @@ backend/src/spotify_to_ytmusic/
     cli/__init__.py                               # argparse + selector + event renderer
     core/
         config.py                                 # All tunables (rate limits, paths)
-        models.py                                 # Dataclasses (Track, Playlist, ...)
+        models.py                                 # Dataclasses (Track, Playlist, Album)
         events.py                                 # MigrationEvent variants
         spotify_client.py                         # spotipy wrapper
         ytmusic_client.py                         # ytmusicapi wrapper + retry
@@ -198,53 +136,30 @@ backend/src/spotify_to_ytmusic/
         report.py                                 # JSON migration report
         text.py                                   # normalize() for fuzzy matching
         headers_parser.py                         # Browser headers → ytmusicapi
+    api/                                          # FastAPI server
+        __init__.py                               # create_app() + CORS
+        server.py                                 # Dev entrypoint
+        sidecar_server.py                         # Tauri sidecar entrypoint
+        models.py, state.py, jobs.py, dependencies.py, serialization.py
+        routes/{auth,health,library,migrate,reports}.py
 backend/data/                                     # Runtime state, gitignored
+backend/tests/                                    # pytest suite
 
-frontend/                                         # Vite + React 19 + TanStack Query + react-router-dom 7
-    public/mockServiceWorker.js                   # MSW worker (generated, committed)
+frontend/
+    src-tauri/                                    # Tauri 2 desktop app
+        Cargo.toml, tauri.conf.json, capabilities/
+        src/{main,lib}.rs
+        binaries/                                 # Sidecar binaries (gitignored)
     src/
         main.tsx                                  # MSW + ErrorBoundary + BrowserRouter + QueryClient
-        App.tsx                                   # <Routes> only — no section enum
-        types/api.ts                              # TS mirror of backend models + events
-        contexts/                                 # SelectionContext (cross-page selection)
-        components/
-            layout/                               # AppShell, Header, Footer, ErrorBoundary, ConnectionStatus
-            ui/                                   # Button, Toast, Card, Input, Skeleton, …
-            library/                              # Tabs, SelectionSummary
-            migrate/                              # PlaylistProgress, AlbumProgress, NotFound, …
-        pages/                                    # Connect, Library, Migrate, Reports/{List,Detail}
-        features/                                 # auth/, library/, migrate/, reports/ — TanStack hooks
-        hooks/                                    # useAutoFocusHeading, useFocusTrap, useMigrationEvents
-        lib/                                      # http (timeout-aware), ws (clean-close aware), query-client, download
-        test/setup.ts                             # Vitest + MSW server lifecycle
-        test/msw/                                 # handlers, fixtures, server, browser
-backend/tests/                                    # pytest suite (migrator, ytmusic_client) — incomplete; see #66
+        App.tsx                                   # <Routes> only
+        contexts/                                 # SelectionContext
+        components/{layout,ui,library,migrate}/
+        pages/{Connect,Library,Migrate,Reports}/
+        features/{auth,library,migrate,reports}/  # TanStack Query hooks
+        hooks/                                    # useAutoFocusHeading, useFocusTrap,
+                                                  # useMigrationEvents, useMigrationState
+        lib/                                      # http, ws, tauri, query-client, download
+        types/api.gen.ts                          # OpenAPI-generated types
+        test/msw/                                 # Handlers, fixtures, server, browser
 ```
-
-## Plan files
-
-There's a plan file at `.claude/plans/` from a previous session. Check it
-for recent decisions before starting a new task — it may have context that
-hasn't made it back to the READMEs yet.
-
-## Roadmap state
-
-The backlog after the May 2026 audit is grouped into four blocks (issues
-#58–#74). State as of the last update:
-
-- **Frontend hardening (#58–#62):** all merged. Selection persists across
-  pages, react-router-dom drives navigation, per-page focus management,
-  WS reducer + rAF-coalesced scroll, lowercase folders, ErrorBoundary
-  global, `http` with timeout.
-- **Backend correctness (#63):** merged. Typed YT Music exceptions.
-- **Backend correctness (#64–#66):** open. Failure events, atomic
-  report writes, full pytest suite.
-- **Integration / FastAPI (#67–#71):** open. Bootstrap, auth, read-only
-  routes, migrate POST + WS, OpenAPI-generated TS types + Vite proxy.
-  **This is the unlock for the frontend's mock-only state.**
-- **Desktop / Tauri (#72–#74):** open. PyInstaller sidecar, Tauri scaffold,
-  OAuth + auto-updater.
-
-The critical path to a real (non-mock) end-to-end app is **#67 → #68 →
-#69 → #70 → #71**. Until #71 lands, the frontend talks to MSW: Connect
-buttons, Migrate jobs, and Reports come from fixtures, not the backend.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
 # backend
 
-Python package, CLI, and (planned) FastAPI server for migrating a Spotify
+Python package, CLI, and FastAPI server for migrating a Spotify
 library to YouTube Music.
 
 ## Requirements
@@ -88,12 +88,22 @@ The server prints the effective URL on startup. Endpoints:
 | Method | Path | Description |
 |---|---|---|
 | `GET` | `/api/health` | Auth status for Spotify and YT Music |
+| `GET` | `/api/auth/spotify/setup` | Whether Spotify credentials are configured |
+| `POST` | `/api/auth/spotify/setup` | Save Spotify credentials (persisted to disk) |
 | `POST` | `/api/auth/spotify` | Returns Spotify OAuth authorize URL |
 | `GET` | `/api/auth/spotify/callback` | OAuth callback, redirects to frontend |
+| `DELETE` | `/api/auth/spotify` | Disconnect Spotify (clears token + creds) |
 | `POST` | `/api/auth/ytmusic` | Saves YT Music browser headers |
+| `DELETE` | `/api/auth/ytmusic` | Disconnect YT Music (clears headers) |
+| `GET` | `/api/playlists` | List playlists |
+| `GET` | `/api/albums` | List saved albums |
+| `POST` | `/api/migrate` | Start migration job |
+| `WS` | `/api/migrate/:jobId/events` | Stream migration events |
+| `GET` | `/api/reports` | List reports |
+| `GET` | `/api/reports/:id` | Single report detail |
 
 All responses are serialized in `camelCase`. CORS is restricted to
-`localhost:5173` (Vite dev) and Tauri origins.
+`localhost:5173`, `127.0.0.1:5173`, and Tauri origins.
 
 ## Usage
 
@@ -194,7 +204,7 @@ core/
 ├── migrator.py        # Orchestrator (no I/O presentation)
 └── report.py          # JSON serialization
 cli/                   # argparse + interactive selector + event-to-print mapping
-api/                   # (planned) FastAPI app
+api/                   # FastAPI app with WebSocket event streaming
 ```
 
 `SpotifyClient` separates discovery from track loading: `list_playlist_summaries()`

--- a/backend/src/spotify_to_ytmusic/api/routes/auth.py
+++ b/backend/src/spotify_to_ytmusic/api/routes/auth.py
@@ -41,6 +41,11 @@ def _get_spotify_oauth(state: str | None = None, redirect_uri: str | None = None
 
 @router.post("/auth/spotify")
 async def auth_spotify(request: Request) -> AuthUrlResponse | ErrorResponse:
+    import os
+    client_id = os.getenv("SPOTIFY_CLIENT_ID", "")
+    client_secret = os.getenv("SPOTIFY_CLIENT_SECRET", "")
+    if not client_id or not client_secret:
+        return ErrorResponse(message="Credenciales de Spotify no configuradas. Configúralas primero.")
     state = secrets.token_urlsafe(32)
     redirect_uri = _resolve_redirect_uri(request)
     state_store.set(state, ttl_seconds=300, redirect_uri=redirect_uri)
@@ -64,18 +69,21 @@ def _resolve_redirect_uri(request: Request) -> str:
 
 @router.get("/auth/spotify/callback")
 async def auth_spotify_callback(request: Request, code: str = "", state: str = ""):
+    from urllib.parse import urlencode
+
     stored = state_store.get(state)
     if not stored:
-        return ErrorResponse(message="Estado de autenticación inválido o expirado.")
+        params = urlencode({"error": "Estado de autenticación inválido o expirado."})
+        return RedirectResponse(url=f"http://127.0.0.1:5173?{params}", status_code=302)
     state_store.delete(state)
     redirect_uri = stored.get("redirect_uri")
     oauth = _get_spotify_oauth(redirect_uri=redirect_uri)
     try:
         oauth.get_access_token(code, as_dict=True)
     except Exception as e:
-        return ErrorResponse(message=f"Error al obtener el token de Spotify: {e}")
-    origin = request.headers.get("origin", "http://localhost:5173")
-    return RedirectResponse(url=origin, status_code=302)
+        params = urlencode({"error": f"Error al conectar con Spotify: {e}"})
+        return RedirectResponse(url=f"http://127.0.0.1:5173?{params}", status_code=302)
+    return RedirectResponse(url="http://127.0.0.1:5173", status_code=302)
 
 
 @router.post("/auth/ytmusic")

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -28,7 +28,9 @@ def _clear_state():
 
 
 @pytest.mark.asyncio
-async def test_auth_spotify_returns_url(client):
+async def test_auth_spotify_returns_url(client, monkeypatch):
+    monkeypatch.setenv("SPOTIFY_CLIENT_ID", "test")
+    monkeypatch.setenv("SPOTIFY_CLIENT_SECRET", "test")
     with patch("spotify_to_ytmusic.api.routes.auth._get_spotify_oauth") as mock_oauth:
         oauth = MagicMock()
         oauth.get_authorize_url.return_value = "https://accounts.spotify.com/authorize?state=test"
@@ -42,7 +44,9 @@ async def test_auth_spotify_returns_url(client):
 
 
 @pytest.mark.asyncio
-async def test_auth_spotify_stores_state(client):
+async def test_auth_spotify_stores_state(client, monkeypatch):
+    monkeypatch.setenv("SPOTIFY_CLIENT_ID", "test")
+    monkeypatch.setenv("SPOTIFY_CLIENT_SECRET", "test")
     with patch("spotify_to_ytmusic.api.routes.auth._get_spotify_oauth") as mock_oauth:
         oauth = MagicMock()
         oauth.get_authorize_url.return_value = "https://accounts.spotify.com/authorize?state=xyz"
@@ -55,9 +59,8 @@ async def test_auth_spotify_stores_state(client):
 @pytest.mark.asyncio
 async def test_auth_spotify_callback_invalid_state(client):
     resp = await client.get("/api/auth/spotify/callback", params={"code": "abc", "state": "nonexistent"})
-    assert resp.status_code == 200
-    data = resp.json()
-    assert "message" in data
+    assert resp.status_code == 302
+    assert "error" in resp.headers["location"]
 
 
 @pytest.mark.asyncio
@@ -70,10 +73,9 @@ async def test_auth_spotify_callback_valid_state(client):
         resp = await client.get(
             "/api/auth/spotify/callback",
             params={"code": "abc", "state": "valid-state"},
-            headers={"origin": "http://localhost:5173"},
         )
         assert resp.status_code == 302
-        assert "localhost:5173" in resp.headers["location"]
+        assert resp.headers["location"] == "http://127.0.0.1:5173"
         oauth.get_access_token.assert_called_once()
 
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,16 +1,18 @@
 # Frontend
 
-Interfaz web para `spotify-to-ytmusic`. Habla con el backend FastAPI vía
-HTTP + WebSocket bajo el prefijo `/api`.
+Interfaz para `spotify-to-ytmusic`. Habla con el backend FastAPI vía HTTP +
+WebSocket bajo el prefijo `/api`. Se empaqueta como app de escritorio con
+Tauri 2.
 
 ## Stack
 
 - **Vite 8** + **React 19** + **TypeScript**
 - **react-router-dom 7** (rutas reales: `/connect`, `/library`,
   `/migrate`, `/reports`, `/reports/:id`)
+- **Tauri 2** (desktop: sidecar + webview nativo)
 - **TanStack Query 5** para estado HTTP
-- **TailwindCSS 3** para estilos
-- **MSW 2** para mockear el backend (modo offline)
+- **TailwindCSS 3** con tema oscuro forzado y color primario morado
+- **MSW 2** para mockear el backend (modo offline/testing)
 - **Vitest** + **Testing Library** para tests
 - WebSocket nativo con reconexión exponencial
 
@@ -131,48 +133,48 @@ src/
 
 ### Patrones que NO hay que romper
 
-- **La selección vive en `SelectionContext`**, no en `useState` por
-  página. `useSelection` (en `features/library/`) delega ahí: si añades
-  una página que necesite leer la selección, lee del context, no
-  reintroduzcas estado local.
+- **La selección vive en `SelectionContext`**, no en `useState` por página.
 - **Las rutas se navegan con `<NavLink>` / `<Link>` / `useNavigate`**.
-  No vuelvas a un enum `section`.
 - **Cada página gestiona su propio focus** con `useAutoFocusHeading`.
-  No hagas un `useEffect` global en `App.tsx`.
-- **Las llamadas HTTP pasan por `lib/http.ts`** para heredar el timeout
-  de 15 s. No llames a `fetch` directamente desde features.
-- **El WS reconecta solo en cierres anormales.** `WsConnection.onclose`
-  trata `wasClean || code === 1000 || code === 1005` como cierre final.
-  Si añades streams nuevos, asegúrate de que el servidor cierra con
-  `1000` cuando termina (MSW lo hace ya, FastAPI tendrá que hacerlo
-  también — ver #70).
+- **Las llamadas HTTP pasan por `lib/http.ts`** para heredar el timeout de 15 s.
+- **El WS reconecta solo en cierres anormales** (wasClean, 1000, 1005).
+- **Dark mode forzado**: `class="dark"` en `<html>`, usar `text-gray-100/200/300`,
+  `bg-gray-700/800/900`, `border-gray-600/700`. No colores claros.
+- **Color primario**: morado (`primary-*`), no `blue-*`.
+- **Migración bloquea navegación**: `useMigrationState` + dialog de confirmación.
+- **Credenciales Spotify**: se guardan vía UI en `spotify_credentials.json`.
+  El `.env` solo sirve para la CLI.
+
+### Tauri (desktop)
+
+```bash
+# Desarrollo
+pnpm tauri dev
+
+# Producción
+python ../backend/scripts/build_sidecar.py  # compila sidecar PyInstaller
+pnpm tauri build                              # .msi / .exe
+```
+
+Ver [`PACKAGING.md`](../PACKAGING.md) para más detalles.
 
 ### Mocks (MSW)
 
-Hoy la app entera corre contra MSW. Los handlers están en
+MSW intercepta peticiones `/api/*` en modo test (`VITE_USE_MSW=true`).
+Los handlers están en
 [`src/test/msw/handlers.ts`](src/test/msw/handlers.ts) y las fixtures en
 [`src/test/msw/fixtures.ts`](src/test/msw/fixtures.ts).
-
-Los patrones de ruta **deben empezar con `*/api/...`**, no `/api/...`.
-Las rutas relativas no matchean en el entorno Node de Vitest (sí en el
-worker del navegador), y los tests fallan silenciosamente con
-`onUnhandledRequest: 'error'`.
-
-```ts
-// ✅ Match en navegador y en Node (Vitest)
-http.get('*/api/playlists', () => HttpResponse.json([...]))
-
-// ❌ Solo match en navegador
-http.get('/api/playlists', () => HttpResponse.json([...]))
-```
 
 ### Contrato con el backend
 
 | Method | Path | Quién lo consume |
 | ------ | ---- | ---------------- |
 | `GET` | `/api/health` | `useHealth` (badge en header) |
+| `GET/POST` | `/api/auth/spotify/setup` | `useSpotifySetup` (credenciales persistidas) |
 | `POST` | `/api/auth/spotify` | `useSpotifyAuth` → redirige a `accounts.spotify.com` |
+| `DELETE` | `/api/auth/spotify` | Botón desconectar en Connect |
 | `POST` | `/api/auth/ytmusic` | `useYTMusicAuth` (envía headers pegados) |
+| `DELETE` | `/api/auth/ytmusic` | Botón desconectar en Connect |
 | `GET` | `/api/playlists` | `usePlaylists` |
 | `GET` | `/api/albums` | `useAlbums` |
 | `POST` | `/api/migrate` | `useStartMigration` (devuelve `{ jobId }`) |

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -11,7 +11,7 @@ export function AppShell({ children }: AppShellProps) {
     <div className="flex min-h-screen flex-col">
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:bg-blue-600 focus:text-white focus:rounded-md focus:font-medium"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:bg-primary-600 focus:text-white focus:rounded-md focus:font-medium"
       >
         Ir al contenido principal
       </a>

--- a/frontend/src/components/layout/ConnectionStatus.tsx
+++ b/frontend/src/components/layout/ConnectionStatus.tsx
@@ -6,7 +6,7 @@ interface BadgeProps {
 }
 
 const stateStyles: Record<ConnectionState, string> = {
-  unknown: 'bg-gray-100 text-gray-500',
+  unknown: 'bg-gray-700 text-gray-400',
   connected: 'bg-green-100 text-green-700',
   disconnected: 'bg-red-100 text-red-700',
 };

--- a/frontend/src/components/layout/ErrorBoundary.tsx
+++ b/frontend/src/components/layout/ErrorBoundary.tsx
@@ -29,7 +29,7 @@ export class ErrorBoundary extends Component<Props, State> {
           role="alert"
           className="flex flex-col items-center justify-center gap-4 p-8 text-center"
         >
-          <p className="text-lg font-medium text-gray-800">Algo salió mal.</p>
+          <p className="text-lg font-medium text-gray-200">Algo salió mal.</p>
           <Button variant="secondary" onClick={this.reset}>
             Reintentar
           </Button>

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,11 +1,11 @@
 export function Footer() {
   return (
-    <footer className="flex h-14 items-center justify-center border-t bg-white px-4">
+    <footer className="flex h-14 items-center justify-center border-t bg-gray-900 px-4">
       <a
         href="https://github.com/vsrd-sftw/spotify-to-ytmusic"
         target="_blank"
         rel="noopener noreferrer"
-        className="text-sm text-gray-500 hover:text-gray-700 hover:underline"
+        className="text-sm text-gray-400 hover:text-gray-300 hover:underline"
       >
         GitHub
       </a>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 import { NavLink } from 'react-router-dom';
 import { useHealth } from '@/features/auth/useHealth';
+import { useMigrationState } from '@/hooks/useMigrationState';
 import { ConnectionStatus } from './ConnectionStatus';
 
 const NAV_ITEMS: { to: string; label: string }[] = [
@@ -11,6 +12,7 @@ const NAV_ITEMS: { to: string; label: string }[] = [
 
 export function Header() {
   const { spotify, ytmusic } = useHealth();
+  const isMigrating = useMigrationState();
 
   return (
     <header className="flex h-14 items-center justify-between border-b border-gray-700 bg-gray-900 px-4 gap-2 sm:gap-4">
@@ -19,13 +21,16 @@ export function Header() {
         {NAV_ITEMS.map((item) => (
           <NavLink
             key={item.to}
-            to={item.to}
+            to={isMigrating ? '#' : item.to}
+            onClick={(e) => isMigrating && e.preventDefault()}
             className={({ isActive }) =>
               [
                 'px-3 py-1.5 rounded-md text-sm font-medium transition-colors shrink-0',
                 isActive
                   ? 'bg-gray-700 text-gray-100'
-                  : 'text-gray-400 hover:text-gray-100 hover:bg-gray-800',
+                  : isMigrating
+                    ? 'text-gray-600 cursor-not-allowed'
+                    : 'text-gray-400 hover:text-gray-100 hover:bg-gray-800',
               ].join(' ')
             }
           >

--- a/frontend/src/components/library/SelectionSummary.tsx
+++ b/frontend/src/components/library/SelectionSummary.tsx
@@ -15,8 +15,8 @@ export function SelectionSummary({ playlistCount, albumCount, onMigrate }: Selec
   const label = isEmpty ? 'Ningún elemento seleccionado' : `${parts.join(', ')} seleccionado${parts.length > 1 || playlistCount + albumCount > 1 ? 's' : ''}`;
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-10 flex items-center justify-between border-t border-gray-200 bg-white px-4 py-3 shadow-md pb-[max(0.75rem,env(safe-area-inset-bottom))]">
-      <span className="text-sm text-gray-600">{label}</span>
+    <div className="fixed bottom-0 left-0 right-0 z-10 flex items-center justify-between border-t border-gray-700 bg-gray-900 px-4 py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+      <span className="text-sm text-gray-400">{label}</span>
       <Button onClick={onMigrate} disabled={isEmpty}>
         Migrar
       </Button>

--- a/frontend/src/components/library/Tabs.tsx
+++ b/frontend/src/components/library/Tabs.tsx
@@ -59,10 +59,10 @@ export function Tabs({ tabs, activeTab, onTabChange, children }: TabsProps) {
               tabIndex={isActive ? 0 : -1}
               onClick={() => onTabChange(tab.id)}
               className={[
-                'px-4 py-2 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500',
+                'px-4 py-2 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500',
                 isActive
-                  ? 'border-b-2 border-blue-600 text-blue-600'
-                  : 'text-gray-600 hover:text-gray-900',
+                  ? 'border-b-2 border-primary-500 text-primary-400'
+                  : 'text-gray-400 hover:text-gray-100',
               ].join(' ')}
             >
               {tab.label}

--- a/frontend/src/components/migrate/AlbumProgress.tsx
+++ b/frontend/src/components/migrate/AlbumProgress.tsx
@@ -24,7 +24,7 @@ const STATUS_STYLES: Record<string, string> = {
 function AlbumItem({ album }: { album: AlbumProgressItem }) {
   return (
     <div className="flex items-center justify-between py-2">
-      <span className="truncate text-gray-900">{album.label}</span>
+      <span className="truncate text-gray-100">{album.label}</span>
       <span
         className={[
           'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
@@ -52,7 +52,7 @@ export function AlbumProgress({
     <Card>
       <CardBody className="space-y-3">
         <div className="flex items-center justify-between">
-          <h3 className="text-lg font-semibold text-gray-900">
+          <h3 className="text-lg font-semibold text-gray-100">
             Álbumes ({albums.length} / {totalDiscovered})
           </h3>
         </div>
@@ -61,7 +61,7 @@ export function AlbumProgress({
           <span className="text-yellow-700">{foundCount} encontrados</span>
           <span className="text-red-700">{notFoundCount} no encontrados</span>
         </div>
-        <div className="divide-y divide-gray-100">
+        <div className="divide-y divide-gray-700">
           {albums.map((album, index) => (
             <AlbumItem key={`${album.label}-${index}`} album={album} />
           ))}

--- a/frontend/src/components/migrate/CompletionSummary.tsx
+++ b/frontend/src/components/migrate/CompletionSummary.tsx
@@ -24,7 +24,7 @@ export function CompletionSummary({
         <h3 className="text-lg font-semibold text-green-800">
           Migration Completada
         </h3>
-        <div className="space-y-1 text-sm text-gray-700">
+        <div className="space-y-1 text-sm text-gray-300">
           <p>
             Pistas: {tracksFound} / {tracksTotal}
           </p>

--- a/frontend/src/components/migrate/NotFound.tsx
+++ b/frontend/src/components/migrate/NotFound.tsx
@@ -38,7 +38,7 @@ export function NotFound({ labels }: NotFoundProps) {
           {isOpen ? <ChevronDown /> : <ChevronRight />}
         </button>
         {isOpen && (
-          <ul className="mt-2 pl-4 list-disc text-sm text-gray-600">
+          <ul className="mt-2 pl-4 list-disc text-sm text-gray-400">
             {labels.map((label, idx) => (
               <li key={idx}>{label}</li>
             ))}

--- a/frontend/src/components/migrate/PlaylistProgress.tsx
+++ b/frontend/src/components/migrate/PlaylistProgress.tsx
@@ -13,8 +13,8 @@ const STATUS_LABELS = {
 };
 
 const STATUS_STYLES = {
-  pending: 'bg-gray-100 text-gray-600',
-  in_progress: 'bg-blue-100 text-blue-700',
+  pending: 'bg-gray-700 text-gray-400',
+  in_progress: 'bg-primary-900/40 text-primary-300',
   completed: 'bg-green-100 text-green-700',
 };
 
@@ -27,7 +27,7 @@ function PlaylistCard({ playlist }: { playlist: PlaylistProgressItem }) {
     <Card className={isInProgress ? 'border-blue-300 ring-2 ring-blue-100' : ''}>
       <CardBody className="space-y-2">
         <div className="flex items-center justify-between">
-          <span className="font-medium text-gray-900 truncate">{playlist.name}</span>
+          <span className="font-medium text-gray-100 truncate">{playlist.name}</span>
           <span
             className={[
               'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
@@ -37,13 +37,13 @@ function PlaylistCard({ playlist }: { playlist: PlaylistProgressItem }) {
             {STATUS_LABELS[playlist.status]}
           </span>
         </div>
-        <div className="h-2 w-full overflow-hidden rounded-full bg-gray-200">
+        <div className="h-2 w-full overflow-hidden rounded-full bg-gray-600">
           <div
-            className="h-full bg-blue-600 transition-all duration-300"
+            className="h-full bg-primary-600 transition-all duration-300"
             style={{ width: `${progressPercent}%` }}
           />
         </div>
-        <div className="flex justify-between text-xs text-gray-500">
+        <div className="flex justify-between text-xs text-gray-400">
           <span>
             {playlist.found} / {playlist.total} encontradas
           </span>
@@ -61,7 +61,7 @@ export function PlaylistProgress({ playlists, totalDiscovered }: PlaylistProgres
 
   return (
     <div className="space-y-3">
-      <h3 className="text-lg font-semibold text-gray-900">
+      <h3 className="text-lg font-semibold text-gray-100">
         Playlists ({playlists.length} / {totalDiscovered})
       </h3>
       <div className="space-y-2">

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -22,7 +22,7 @@ export interface CardFooterProps {
 
 export function Card({ children, className = '' }: CardProps) {
   return (
-    <div className={['rounded-lg border border-gray-200 bg-white shadow-sm', className].join(' ')}>
+    <div className={['rounded-lg border border-gray-700 bg-gray-800', className].join(' ')}>
       {children}
     </div>
   )
@@ -30,7 +30,7 @@ export function Card({ children, className = '' }: CardProps) {
 
 export function CardHeader({ children, className = '' }: CardHeaderProps) {
   return (
-    <div className={['border-b border-gray-200 px-4 py-3', className].join(' ')}>
+    <div className={['border-b border-gray-700 px-4 py-3', className].join(' ')}>
       {children}
     </div>
   )
@@ -46,7 +46,7 @@ export function CardBody({ children, className = '' }: CardBodyProps) {
 
 export function CardFooter({ children, className = '' }: CardFooterProps) {
   return (
-    <div className={['border-t border-gray-200 px-4 py-3', className].join(' ')}>
+    <div className={['border-t border-gray-700 px-4 py-3', className].join(' ')}>
       {children}
     </div>
   )

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -11,8 +11,8 @@ export function EmptyState({ title, description, illustration, cta }: EmptyState
   return (
     <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
       {illustration && <div aria-hidden="true">{illustration}</div>}
-      <p className="text-lg font-semibold text-gray-800">{title}</p>
-      {description && <p className="text-sm text-gray-500">{description}</p>}
+      <p className="text-lg font-semibold text-gray-200">{title}</p>
+      {description && <p className="text-sm text-gray-400">{description}</p>}
       {cta && <div>{cta}</div>}
     </div>
   )

--- a/frontend/src/components/ui/List.test.tsx
+++ b/frontend/src/components/ui/List.test.tsx
@@ -90,7 +90,7 @@ describe('ListItem selection', () => {
       </List>
     )
     const listItems = screen.getAllByRole('listitem')
-    expect(listItems[0]).toHaveClass('bg-blue-50')
-    expect(listItems[1]).not.toHaveClass('bg-blue-50')
+    expect(listItems[0]).toHaveClass('bg-primary-900/30')
+    expect(listItems[1]).not.toHaveClass('bg-primary-900/30')
   })
 })

--- a/frontend/src/components/ui/List.tsx
+++ b/frontend/src/components/ui/List.tsx
@@ -22,7 +22,7 @@ export function List({ children, onSelect, selectedIds = [], className = '' }: L
 
   return (
     <ListContext.Provider value={value}>
-      <ul className={['divide-y divide-gray-200', className].join(' ')}>
+      <ul className={['divide-y divide-gray-600', className].join(' ')}>
         {children}
       </ul>
     </ListContext.Provider>
@@ -51,8 +51,8 @@ export function ListItem({ id, children, className = '', onSelect }: ListItemPro
   return (
     <li
       className={[
-        'flex items-center gap-3 px-4 py-3 hover:bg-gray-50 cursor-pointer',
-        isSelected && 'bg-blue-50',
+        'flex items-center gap-3 px-4 py-3 hover:bg-gray-700 cursor-pointer',
+        isSelected && 'bg-primary-900/30',
         className,
       ].join(' ')}
       onClick={handleClick}

--- a/frontend/src/components/ui/Skeleton.tsx
+++ b/frontend/src/components/ui/Skeleton.tsx
@@ -21,7 +21,7 @@ export function Skeleton({ variant = 'text', width, height, className = '' }: Sk
   return (
     <div
       data-testid="skeleton"
-      className={['animate-pulse bg-gray-200', variantStyles[variant], className].join(' ')}
+      className={['animate-pulse bg-gray-600', variantStyles[variant], className].join(' ')}
       style={style}
     />
   )

--- a/frontend/src/components/ui/Spinner.tsx
+++ b/frontend/src/components/ui/Spinner.tsx
@@ -19,7 +19,7 @@ export function Spinner({ size = 'md', className = '', label = 'Loading' }: Spin
       className={['inline-flex items-center justify-center', className].join(' ')}
     >
       <svg
-        className={['animate-spin text-gray-600', sizeStyles[size]].join(' ')}
+        className={['animate-spin text-gray-400', sizeStyles[size]].join(' ')}
         viewBox="0 0 24 24"
         fill="none"
       >

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -6,7 +6,7 @@ export type { ToastProviderProps } from '../../lib/ToastContextValue'
 const typeStyles = {
   success: 'bg-green-50 border-green-200 text-green-800',
   error: 'bg-red-50 border-red-200 text-red-800',
-  info: 'bg-blue-50 border-blue-200 text-blue-800',
+  info: 'bg-primary-900/20 border-primary-800 text-primary-200',
 }
 
 const icons = {
@@ -35,7 +35,7 @@ interface ToastItemProps {
 function ToastItem({ toast, onDismiss }: ToastItemProps) {
   return (
     <div
-      className={['flex items-center gap-3 rounded-md border p-4 shadow-sm', typeStyles[toast.type]].join(' ')}
+      className={['flex items-center gap-3 rounded-md border p-4', typeStyles[toast.type]].join(' ')}
       role="alert"
     >
       <span className="flex-shrink-0">{icons[toast.type]}</span>

--- a/frontend/src/hooks/useMigrationState.ts
+++ b/frontend/src/hooks/useMigrationState.ts
@@ -1,0 +1,19 @@
+import { useSyncExternalStore } from 'react';
+
+let _isMigrating = false;
+const _listeners = new Set<() => void>();
+
+export function setIsMigrating(v: boolean) {
+  _isMigrating = v;
+  _listeners.forEach((fn) => fn());
+}
+
+export function useMigrationState(): boolean {
+  return useSyncExternalStore(
+    (cb) => {
+      _listeners.add(cb);
+      return () => _listeners.delete(cb);
+    },
+    () => _isMigrating,
+  );
+}

--- a/frontend/src/pages/Connect/Spotify.tsx
+++ b/frontend/src/pages/Connect/Spotify.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Button, FieldError, Input, Label } from '@/components/ui'
 import { http } from '@/lib/http'
 import { useSpotifyAuth } from '@/features/auth/useSpotifyAuth'
@@ -17,6 +17,16 @@ export function SpotifyConnect() {
   const invalidateHealth = useInvalidateHealth()
   const [clientId, setClientId] = useState('')
   const [clientSecret, setClientSecret] = useState('')
+  const [callbackError, setCallbackError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const err = params.get('error')
+    if (err) {
+      setCallbackError(decodeURIComponent(err))
+      window.history.replaceState({}, '', window.location.pathname)
+    }
+  }, [])
 
   const isConnected = spotify === 'connected'
 
@@ -35,6 +45,12 @@ export function SpotifyConnect() {
       >
         Conectar Spotify
       </h2>
+
+      {callbackError && (
+        <div className="rounded-md border border-red-700 bg-red-900/30 p-3">
+          <p className="text-sm text-red-300">{callbackError}</p>
+        </div>
+      )}
 
       {isConnected ? (
         <div className="flex flex-col gap-2">

--- a/frontend/src/pages/Connect/Spotify.tsx
+++ b/frontend/src/pages/Connect/Spotify.tsx
@@ -31,7 +31,7 @@ export function SpotifyConnect() {
     >
       <h2
         id="spotify-connect-heading"
-        className="text-xl font-semibold text-gray-900"
+        className="text-xl font-semibold text-gray-100"
       >
         Conectar Spotify
       </h2>
@@ -53,15 +53,15 @@ export function SpotifyConnect() {
       ) : (
         <>
           {configured === false && (
-            <div className="flex flex-col gap-3 rounded-md border border-gray-200 p-4">
-              <p className="text-sm text-gray-600">
+            <div className="flex flex-col gap-3 rounded-md border border-gray-700 p-4">
+              <p className="text-sm text-gray-400">
                 Configura tus credenciales de desarrollador de Spotify. Puedes
                 obtenerlas en el{' '}
                 <a
                   href="https://developer.spotify.com/dashboard"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-blue-600 underline"
+                  className="text-primary-400 underline"
                 >
                   Dashboard de Spotify
                 </a>
@@ -99,7 +99,7 @@ export function SpotifyConnect() {
             </div>
           )}
 
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-gray-400">
             Inicia sesión con tu cuenta de Spotify para que podamos leer tus
             playlists y álbumes guardados. Serás redirigido a Spotify para
             autorizar el acceso.

--- a/frontend/src/pages/Connect/YTMusic.tsx
+++ b/frontend/src/pages/Connect/YTMusic.tsx
@@ -19,7 +19,7 @@ export function YTMusicConnect() {
 
   return (
     <section aria-labelledby="ytmusic-connect-heading" className="flex flex-col gap-4 p-8">
-      <h2 id="ytmusic-connect-heading" className="text-xl font-semibold text-gray-900">
+      <h2 id="ytmusic-connect-heading" className="text-xl font-semibold text-gray-100">
         Conectar YouTube Music
       </h2>
 
@@ -39,10 +39,10 @@ export function YTMusicConnect() {
         </div>
       ) : (
         <>
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-gray-400">
             Para autenticar con YouTube Music necesitas capturar los headers de tu navegador:
           </p>
-          <ol className="list-decimal list-inside space-y-1 text-sm text-gray-600">
+          <ol className="list-decimal list-inside space-y-1 text-sm text-gray-400">
             <li>Abre YouTube Music en Chrome o Firefox.</li>
             <li>Abre las DevTools (F12) y ve a la pestaña <strong>Network</strong>.</li>
             <li>Recarga la página y filtra las peticiones por <code>browse</code>.</li>

--- a/frontend/src/pages/Library/index.tsx
+++ b/frontend/src/pages/Library/index.tsx
@@ -35,7 +35,7 @@ export function LibraryPage() {
         id="library-heading"
         ref={headingRef}
         tabIndex={-1}
-        className="mb-4 text-xl font-semibold text-gray-900 outline-none"
+        className="mb-4 text-xl font-semibold text-gray-100 outline-none"
       >
         Biblioteca
       </h2>

--- a/frontend/src/pages/Migrate/EventLog.tsx
+++ b/frontend/src/pages/Migrate/EventLog.tsx
@@ -23,7 +23,7 @@ const stateLabels: Record<WsState, string> = {
 const stateColors: Record<WsState, string> = {
   connecting: 'bg-yellow-100 text-yellow-800',
   open: 'bg-green-100 text-green-800',
-  closed: 'bg-gray-100 text-gray-600',
+  closed: 'bg-gray-700 text-gray-400',
   error: 'bg-red-100 text-red-800',
   reconnecting: 'bg-yellow-100 text-yellow-800',
   exhausted: 'bg-red-100 text-red-800',
@@ -93,7 +93,7 @@ export function EventLog({ jobId }: EventLogProps) {
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center gap-2">
-        <span className="text-sm text-gray-600">Estado:</span>
+        <span className="text-sm text-gray-400">Estado:</span>
         <span className={`px-2 py-0.5 rounded text-xs font-medium ${stateColors[state]}`}>
           {stateLabels[state]}
         </span>
@@ -103,13 +103,13 @@ export function EventLog({ jobId }: EventLogProps) {
         ref={containerRef}
         role="log"
         aria-live="polite"
-        className="h-64 overflow-y-auto bg-gray-50 border rounded-md p-3 font-mono text-sm"
+        className="h-64 overflow-y-auto bg-gray-800 border rounded-md p-3 font-mono text-sm"
       >
         {events.length === 0 && !isReconnecting ? (
-          <span className="text-gray-400">Esperando eventos...</span>
+          <span className="text-gray-500">Esperando eventos...</span>
         ) : (
           events.map((event, idx) => (
-            <div key={idx} className="py-0.5 text-gray-700">
+            <div key={idx} className="py-0.5 text-gray-300">
               {formatEvent(event)}
             </div>
           ))

--- a/frontend/src/pages/Migrate/index.tsx
+++ b/frontend/src/pages/Migrate/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSelection } from '@/features/library';
 import { useMigrationSelection, useStartMigration } from '@/features/migrate';
@@ -6,12 +6,36 @@ import { usePlaylists } from '@/features/library/usePlaylists';
 import { useAlbums } from '@/features/library/useAlbums';
 import { useSelectionContext } from '@/contexts/useSelectionContext';
 import { useAutoFocusHeading } from '@/hooks/useAutoFocusHeading';
+import { setIsMigrating } from '@/hooks/useMigrationState';
 import { EventLog } from './EventLog';
 
 export function MigratePage() {
   const navigate = useNavigate();
   const [jobId, setJobId] = useState<string | null>(null);
+  const [confirmExit, setConfirmExit] = useState(false);
   const { clearAll } = useSelectionContext();
+
+  useEffect(() => {
+    if (!jobId) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [jobId]);
+
+  useEffect(() => {
+    setIsMigrating(jobId !== null);
+    return () => setIsMigrating(false);
+  }, [jobId]);
+
+  const handleNavigate = (to: string) => {
+    if (jobId) {
+      setConfirmExit(true);
+      return;
+    }
+    navigate(to);
+  };
 
   const { data: playlists = [] } = usePlaylists();
   const { data: albums = [] } = useAlbums();
@@ -39,14 +63,14 @@ export function MigratePage() {
         <h2
           ref={headingRef}
           tabIndex={-1}
-          className="text-xl font-semibold text-gray-900 outline-none"
+          className="text-xl font-semibold text-gray-100 outline-none"
         >
           Migrar
         </h2>
-        <p className="text-gray-600">No hay elementos seleccionados.</p>
+        <p className="text-gray-400">No hay elementos seleccionados.</p>
         <button
-          onClick={() => navigate('/library')}
-          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+          onClick={() => handleNavigate('/library')}
+          className="px-4 py-2 bg-primary-600 text-white rounded hover:bg-primary-700"
         >
           Ir a Biblioteca
         </button>
@@ -56,16 +80,44 @@ export function MigratePage() {
 
   if (jobId) {
     return (
-      <section className="p-4 sm:p-6">
-        <h2
-          ref={headingRef}
-          tabIndex={-1}
-          className="mb-4 text-xl font-semibold text-gray-900 outline-none"
-        >
-          Migración en Progreso
-        </h2>
-        <EventLog jobId={jobId} />
-      </section>
+      <>
+        {confirmExit && (
+          <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+            <div className="bg-gray-800 border border-gray-600 rounded-lg p-6 shadow-lg max-w-sm mx-4">
+              <p className="text-gray-100 mb-4">
+                Hay una migración en progreso. Si sales, se interrumpirá.
+              </p>
+              <div className="flex gap-2 justify-end">
+                <button
+                  onClick={() => setConfirmExit(false)}
+                  className="px-4 py-2 border border-gray-600 rounded hover:bg-gray-700 text-gray-200"
+                >
+                  Quedarse
+                </button>
+                <button
+                  onClick={() => {
+                    setConfirmExit(false);
+                    handleNavigate('/library');
+                  }}
+                  className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+                >
+                  Salir
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+        <section className="p-4 sm:p-6">
+          <h2
+            ref={headingRef}
+            tabIndex={-1}
+            className="mb-4 text-xl font-semibold text-gray-100 outline-none"
+          >
+            Migración en Progreso
+          </h2>
+          <EventLog jobId={jobId} />
+        </section>
+      </>
     );
   }
 
@@ -74,11 +126,11 @@ export function MigratePage() {
       <h2
         ref={headingRef}
         tabIndex={-1}
-        className="text-xl font-semibold text-gray-900 outline-none"
-      >
-        Confirmar Migración
+          className="text-xl font-semibold text-gray-100 outline-none"
+        >
+          Confirmar Migración
       </h2>
-      <div className="text-gray-700">
+      <div className="text-gray-300">
         <p>¿Confirmas que quieres migrar?</p>
         <ul className="mt-2 list-disc list-inside">
           <li>Playlists: {migration.playlistCount}</li>
@@ -88,8 +140,8 @@ export function MigratePage() {
       </div>
       <div className="flex gap-2">
         <button
-          onClick={() => navigate('/library')}
-          className="px-4 py-2 border border-gray-300 rounded hover:bg-gray-50"
+          onClick={() => handleNavigate('/library')}
+          className="px-4 py-2 border border-gray-600 rounded hover:bg-gray-700"
         >
           Cancelar
         </button>
@@ -101,7 +153,7 @@ export function MigratePage() {
             })
           }
           disabled={startMigration.isLoading}
-          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+          className="px-4 py-2 bg-primary-600 text-white rounded hover:bg-primary-700 disabled:opacity-50"
         >
           {startMigration.isLoading ? 'Iniciando...' : 'Iniciar Migración'}
         </button>

--- a/frontend/src/pages/Reports/Detail.tsx
+++ b/frontend/src/pages/Reports/Detail.tsx
@@ -39,7 +39,7 @@ export function ReportDetail({ report, onClose, onDownload }: ReportDetailProps)
         <h2
           ref={headingRef}
           tabIndex={-1}
-          className="text-lg font-semibold text-gray-900 outline-none"
+          className="text-lg font-semibold text-gray-100 outline-none"
         >
           {resolved.id ? `Reporte ${resolved.id.slice(0, 8)}` : 'Detalle del reporte'}
         </h2>
@@ -48,7 +48,7 @@ export function ReportDetail({ report, onClose, onDownload }: ReportDetailProps)
             <button
               type="button"
               onClick={() => onDownload(resolved)}
-              className="px-3 py-1.5 text-sm font-medium text-gray-700 border border-gray-300 rounded-md hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              className="px-3 py-1.5 text-sm font-medium text-gray-300 border border-gray-600 rounded-md hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
             >
               Descargar JSON
             </button>
@@ -56,7 +56,7 @@ export function ReportDetail({ report, onClose, onDownload }: ReportDetailProps)
           <button
             type="button"
             onClick={onClose}
-            className="px-3 py-1.5 text-sm font-medium text-gray-700 border border-gray-300 rounded-md hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            className="px-3 py-1.5 text-sm font-medium text-gray-300 border border-gray-600 rounded-md hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
           >
             Cerrar
           </button>
@@ -81,19 +81,19 @@ export function ReportDetail({ report, onClose, onDownload }: ReportDetailProps)
       {!isLoading && !error && (
         <div className="flex flex-col gap-4">
           <section>
-            <h3 className="mb-2 text-sm font-semibold text-gray-700">
+            <h3 className="mb-2 text-sm font-semibold text-gray-300">
               Playlists ({resolved.playlists.length})
             </h3>
             {resolved.playlists.length === 0 ? (
-              <p className="text-sm text-gray-500">No se migraron playlists.</p>
+              <p className="text-sm text-gray-400">No se migraron playlists.</p>
             ) : (
               <div className="flex flex-col gap-2">
                 {resolved.playlists.map((pl, idx) => (
                   <Card key={idx}>
                     <CardBody>
                       <div className="flex items-center justify-between">
-                        <span className="text-sm font-medium text-gray-900">{pl.name}</span>
-                        <span className="text-sm text-gray-600">
+                        <span className="text-sm font-medium text-gray-100">{pl.name}</span>
+                        <span className="text-sm text-gray-400">
                           {pl.found}/{pl.total} encontradas
                         </span>
                       </div>
@@ -105,11 +105,11 @@ export function ReportDetail({ report, onClose, onDownload }: ReportDetailProps)
           </section>
 
           <section>
-            <h3 className="mb-2 text-sm font-semibold text-gray-700">
+            <h3 className="mb-2 text-sm font-semibold text-gray-300">
               Álbumes ({resolved.albums.length})
             </h3>
             {resolved.albums.length === 0 ? (
-              <p className="text-sm text-gray-500">No se migraron álbumes.</p>
+              <p className="text-sm text-gray-400">No se migraron álbumes.</p>
             ) : (
               <div className="flex flex-col gap-2">
                 {resolved.albums.map((album, idx) => {
@@ -122,7 +122,7 @@ export function ReportDetail({ report, onClose, onDownload }: ReportDetailProps)
                     <Card key={idx}>
                       <CardBody>
                         <div className="flex items-center justify-between">
-                          <span className="text-sm font-medium text-gray-900">{album.label}</span>
+                          <span className="text-sm font-medium text-gray-100">{album.label}</span>
                           <span className={`text-sm font-medium ${statusColors[album.status]}`}>
                             {album.status}
                           </span>
@@ -136,19 +136,19 @@ export function ReportDetail({ report, onClose, onDownload }: ReportDetailProps)
           </section>
 
           <section>
-            <h3 className="mb-2 text-sm font-semibold text-gray-700">
+            <h3 className="mb-2 text-sm font-semibold text-gray-300">
               No encontrados ({resolved.notFound.length})
             </h3>
             {resolved.notFound.length === 0 ? (
-              <p className="text-sm text-gray-500">Todos los items fueron encontrados.</p>
+              <p className="text-sm text-gray-400">Todos los items fueron encontrados.</p>
             ) : (
               <div className="flex flex-col gap-2">
                 {resolved.notFound.map((item, idx) => (
                   <Card key={idx}>
                     <CardBody>
                       <div className="flex flex-col gap-0.5">
-                        <span className="text-sm font-medium text-gray-900">{item.item}</span>
-                        <span className="text-xs text-gray-500">{item.context}</span>
+                        <span className="text-sm font-medium text-gray-100">{item.item}</span>
+                        <span className="text-xs text-gray-400">{item.context}</span>
                       </div>
                     </CardBody>
                   </Card>

--- a/frontend/src/pages/Reports/List.tsx
+++ b/frontend/src/pages/Reports/List.tsx
@@ -27,10 +27,10 @@ function ReportItem({
         <CardBody>
           <div className="flex items-center justify-between">
             <div className="flex flex-col gap-1">
-              <span className="text-sm font-medium text-gray-900">
+              <span className="text-sm font-medium text-gray-100">
                 {report.id ? `Reporte ${report.id.slice(0, 8)}` : 'Reporte sin ID'}
               </span>
-              <div className="flex gap-3 text-xs text-gray-500">
+              <div className="flex gap-3 text-xs text-gray-400">
                 <span>{playlistCount} playlist{playlistCount !== 1 ? 's' : ''}</span>
                 <span>{albumCount} álbum{albumCount !== 1 ? 'es' : ''}</span>
                 {missCount > 0 && (
@@ -38,7 +38,7 @@ function ReportItem({
                 )}
               </div>
             </div>
-            <span className="text-gray-500">→</span>
+            <span className="text-gray-400">→</span>
           </div>
         </CardBody>
       </Card>

--- a/frontend/src/pages/Reports/index.tsx
+++ b/frontend/src/pages/Reports/index.tsx
@@ -15,7 +15,7 @@ export function ReportsListPage() {
       <h2
         ref={headingRef}
         tabIndex={-1}
-        className="text-xl font-semibold text-gray-900 outline-none"
+        className="text-xl font-semibold text-gray-100 outline-none"
       >
         Reportes
       </h2>


### PR DESCRIPTION
﻿## Summary

- **Dark mode consistency**: 25+ components updated — all remaining `bg-white`, `text-gray-900`, `border-gray-200`, `bg-blue-*` etc. replaced with dark equivalents across layout, UI, library, migrate, and page components
- **Navigation blocker**: migration page prevents exit via `window.onbeforeunload` + custom confirmation dialog. Header nav links disabled during migration via `useMigrationState` (useSyncExternalStore)
- **Documentation**: CLAUDE.md fully rewritten to reflect current state (FastAPI live, Tauri scaffolded, dark mode enforced). backend/README.md updated with full API endpoint table. frontend/README.md updated with Tauri section, dark mode conventions, new endpoints

## Test plan

- [X] `pytest` — 103 passed
- [X] `pnpm lint` — clean
- [X] `pnpm build` — OK
- [X] `pnpm test:run` — 257 passed
