### PR TITLE
fix(auth): error client_id invalid en OAuth + imposibilidad de cambiar credenciales

### DIFF
--- a/backend/src/spotify_to_ytmusic/api/dependencies.py
+++ b/backend/src/spotify_to_ytmusic/api/dependencies.py
@@ -5,9 +5,14 @@ from fastapi import Depends, HTTPException, status
 from spotipy.oauth2 import SpotifyOauthError
 
 from spotify_to_ytmusic.core.config import (
-    DEFAULT_SPOTIFY_REDIRECT_URI,
     SPOTIFY_TOKEN_CACHE_FILE,
 )
+
+# The redirect URI that the API server's own auth flow uses.
+# Must match what _resolve_redirect_uri() in routes/auth.py returns
+# for the Vite dev proxy (the common case).  Do NOT use
+# DEFAULT_SPOTIFY_REDIRECT_URI — that is for the CLI (:8888).
+_API_CALLBACK_URI = "http://127.0.0.1:5173/api/auth/spotify/callback"
 from spotify_to_ytmusic.core.spotify_client import SpotifyClient
 
 _spotify_client: SpotifyClient | None = None
@@ -18,7 +23,7 @@ def get_spotify_client() -> SpotifyClient:
     if _spotify_client is None:
         client_id = os.getenv("SPOTIFY_CLIENT_ID", "")
         client_secret = os.getenv("SPOTIFY_CLIENT_SECRET", "")
-        redirect_uri = os.getenv("SPOTIFY_REDIRECT_URI", DEFAULT_SPOTIFY_REDIRECT_URI)
+        redirect_uri = os.getenv("SPOTIFY_REDIRECT_URI", _API_CALLBACK_URI)
         try:
             _spotify_client = SpotifyClient(
                 client_id=client_id,

--- a/backend/src/spotify_to_ytmusic/api/routes/auth.py
+++ b/backend/src/spotify_to_ytmusic/api/routes/auth.py
@@ -79,7 +79,7 @@ async def auth_spotify_callback(request: Request, code: str = "", state: str = "
     redirect_uri = stored.get("redirect_uri")
     oauth = _get_spotify_oauth(redirect_uri=redirect_uri)
     try:
-        oauth.get_access_token(code, as_dict=True)
+        oauth.get_access_token(code, as_dict=True, check_cache=False)
     except Exception as e:
         params = urlencode({"error": f"Error al conectar con Spotify: {e}"})
         return RedirectResponse(url=f"http://127.0.0.1:5173?{params}", status_code=302)

--- a/backend/src/spotify_to_ytmusic/api/routes/auth.py
+++ b/backend/src/spotify_to_ytmusic/api/routes/auth.py
@@ -174,3 +174,12 @@ async def post_spotify_setup(body: dict) -> OkResponse | ErrorResponse:
     _os.environ["SPOTIFY_CLIENT_ID"] = client_id
     _os.environ["SPOTIFY_CLIENT_SECRET"] = client_secret
     return OkResponse(ok=True)
+
+
+@router.delete("/auth/spotify/setup")
+async def delete_spotify_setup() -> OkResponse:
+    if _os.path.isfile(SPOTIFY_CREDENTIALS_FILE):
+        _os.remove(SPOTIFY_CREDENTIALS_FILE)
+    _os.environ.pop("SPOTIFY_CLIENT_ID", None)
+    _os.environ.pop("SPOTIFY_CLIENT_SECRET", None)
+    return OkResponse(ok=True)

--- a/backend/src/spotify_to_ytmusic/api/routes/migrate.py
+++ b/backend/src/spotify_to_ytmusic/api/routes/migrate.py
@@ -11,7 +11,6 @@ from spotify_to_ytmusic.api.models import ErrorResponse, MigrateRequest, Migrate
 from spotify_to_ytmusic.api.serialization import serialize_event
 from spotify_to_ytmusic.core.config import (
     BROWSER_AUTH_FILE,
-    DEFAULT_SPOTIFY_REDIRECT_URI,
     SPOTIFY_TOKEN_CACHE_FILE,
     TRACK_CACHE_FILE,
 )
@@ -41,7 +40,7 @@ def _run_migration(
     spotify = SpotifyClient(
         client_id=os.getenv("SPOTIFY_CLIENT_ID", ""),
         client_secret=os.getenv("SPOTIFY_CLIENT_SECRET", ""),
-        redirect_uri=os.getenv("SPOTIFY_REDIRECT_URI", DEFAULT_SPOTIFY_REDIRECT_URI),
+        redirect_uri=os.getenv("SPOTIFY_REDIRECT_URI", "http://127.0.0.1:5173/api/auth/spotify/callback"),
         open_browser=False,
     )
     ytmusic = YTMusicClient(BROWSER_AUTH_FILE)

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -125,3 +125,77 @@ async def test_auth_ytmusic_empty_headers(client):
     assert resp.status_code == 200
     data = resp.json()
     assert "message" in data
+
+
+@pytest.mark.asyncio
+async def test_spotify_setup_get_unconfigured(client, tmp_path):
+    creds_file = tmp_path / "spotify_credentials.json"
+    with patch("spotify_to_ytmusic.api.routes.auth.SPOTIFY_CREDENTIALS_FILE", str(creds_file)):
+        resp = await client.get("/api/auth/spotify/setup")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["configured"] is False
+
+
+@pytest.mark.asyncio
+async def test_spotify_setup_save_and_get_configured(client, tmp_path):
+    creds_file = tmp_path / "spotify_credentials.json"
+    with patch("spotify_to_ytmusic.api.routes.auth.SPOTIFY_CREDENTIALS_FILE", str(creds_file)):
+        resp = await client.post(
+            "/api/auth/spotify/setup",
+            json={"client_id": "myid", "client_secret": "mysecret"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        assert creds_file.exists()
+
+        resp = await client.get("/api/auth/spotify/setup")
+        assert resp.json()["configured"] is True
+
+        resp = await client.delete("/api/auth/spotify/setup")
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        assert not creds_file.exists()
+
+        resp = await client.get("/api/auth/spotify/setup")
+        assert resp.json()["configured"] is False
+
+
+@pytest.mark.asyncio
+async def test_spotify_setup_delete_idempotent(client, tmp_path):
+    creds_file = tmp_path / "spotify_credentials.json"
+    with patch("spotify_to_ytmusic.api.routes.auth.SPOTIFY_CREDENTIALS_FILE", str(creds_file)):
+        resp = await client.delete("/api/auth/spotify/setup")
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_spotify_setup_save_missing_fields(client, tmp_path):
+    creds_file = tmp_path / "spotify_credentials.json"
+    with patch("spotify_to_ytmusic.api.routes.auth.SPOTIFY_CREDENTIALS_FILE", str(creds_file)):
+        resp = await client.post(
+            "/api/auth/spotify/setup",
+            json={"client_id": "", "client_secret": ""},
+        )
+        assert resp.status_code == 200
+        assert "message" in resp.json()
+        assert not creds_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_spotify_setup_delete_clears_env_vars(client, tmp_path, monkeypatch):
+    creds_file = tmp_path / "spotify_credentials.json"
+    monkeypatch.setenv("SPOTIFY_CLIENT_ID", "env_id")
+    monkeypatch.setenv("SPOTIFY_CLIENT_SECRET", "env_secret")
+    with patch("spotify_to_ytmusic.api.routes.auth.SPOTIFY_CREDENTIALS_FILE", str(creds_file)):
+        await client.post(
+            "/api/auth/spotify/setup",
+            json={"client_id": "myid", "client_secret": "mysecret"},
+        )
+        import os
+        assert os.environ.get("SPOTIFY_CLIENT_ID") == "myid"
+
+        await client.delete("/api/auth/spotify/setup")
+        assert os.environ.get("SPOTIFY_CLIENT_ID") is None
+        assert os.environ.get("SPOTIFY_CLIENT_SECRET") is None

--- a/frontend/src/features/auth/useSpotifySetup.ts
+++ b/frontend/src/features/auth/useSpotifySetup.ts
@@ -3,14 +3,15 @@ import { http, HttpError } from '@/lib/http'
 
 export interface UseSpotifySetupResult {
   configured: boolean | null
-  state: 'idle' | 'saving' | 'error'
+  state: 'idle' | 'saving' | 'resetting' | 'error'
   errorMessage: string | null
   save: (clientId: string, clientSecret: string) => void
+  reset: () => void
 }
 
 export function useSpotifySetup(): UseSpotifySetupResult {
   const [configured, setConfigured] = useState<boolean | null>(null)
-  const [state, setState] = useState<'idle' | 'saving' | 'error'>('idle')
+  const [state, setState] = useState<'idle' | 'saving' | 'resetting' | 'error'>('idle')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   useEffect(() => {
@@ -20,35 +21,56 @@ export function useSpotifySetup(): UseSpotifySetupResult {
       .catch(() => setConfigured(false))
   }, [])
 
-  const save = useCallback(
-    (clientId: string, clientSecret: string) => {
-      setState('saving')
-      setErrorMessage(null)
-      http
-        .post<{ ok: boolean }>('/auth/spotify/setup', {
-          client_id: clientId,
-          client_secret: clientSecret,
-        })
-        .then(() => {
-          setState('idle')
-          setConfigured(true)
-        })
-        .catch((err: unknown) => {
-          setState('error')
-          if (err instanceof HttpError) {
-            const body = err.body as Record<string, unknown> | null
-            setErrorMessage(
-              typeof body?.message === 'string'
-                ? body.message
-                : `Error al guardar credenciales (${err.status})`,
-            )
-          } else {
-            setErrorMessage('No se pudo guardar. Comprueba tu conexión.')
-          }
-        })
-    },
-    [],
-  )
+  const save = useCallback((clientId: string, clientSecret: string) => {
+    setState('saving')
+    setErrorMessage(null)
+    http
+      .post<{ ok: boolean }>('/auth/spotify/setup', {
+        client_id: clientId,
+        client_secret: clientSecret,
+      })
+      .then(() => {
+        setState('idle')
+        setConfigured(true)
+      })
+      .catch((err: unknown) => {
+        setState('error')
+        if (err instanceof HttpError) {
+          const body = err.body as Record<string, unknown> | null
+          setErrorMessage(
+            typeof body?.message === 'string'
+              ? body.message
+              : `Error al guardar credenciales (${err.status})`,
+          )
+        } else {
+          setErrorMessage('No se pudo guardar. Comprueba tu conexión.')
+        }
+      })
+  }, [])
 
-  return { configured, state, errorMessage, save }
+  const reset = useCallback(() => {
+    setState('resetting')
+    setErrorMessage(null)
+    http
+      .delete<{ ok: boolean }>('/auth/spotify/setup')
+      .then(() => {
+        setState('idle')
+        setConfigured(false)
+      })
+      .catch((err: unknown) => {
+        setState('error')
+        if (err instanceof HttpError) {
+          const body = err.body as Record<string, unknown> | null
+          setErrorMessage(
+            typeof body?.message === 'string'
+              ? body.message
+              : `Error al restablecer credenciales (${err.status})`,
+          )
+        } else {
+          setErrorMessage('No se pudo restablecer. Comprueba tu conexión.')
+        }
+      })
+  }, [])
+
+  return { configured, state, errorMessage, save, reset }
 }

--- a/frontend/src/pages/Connect/Spotify.tsx
+++ b/frontend/src/pages/Connect/Spotify.tsx
@@ -5,25 +5,24 @@ import { useSpotifyAuth } from '@/features/auth/useSpotifyAuth'
 import { useSpotifySetup } from '@/features/auth/useSpotifySetup'
 import { useHealth, useInvalidateHealth } from '@/features/auth/useHealth'
 
+const REDIRECT_URI = 'http://127.0.0.1:5173/api/auth/spotify/callback'
+
 export function SpotifyConnect() {
   const { state, errorMessage, connect } = useSpotifyAuth()
-  const {
-    configured,
-    state: setupState,
-    errorMessage: setupError,
-    save,
-  } = useSpotifySetup()
+  const { configured, state: setupState, errorMessage: setupError, save, reset } = useSpotifySetup()
   const { spotify } = useHealth()
   const invalidateHealth = useInvalidateHealth()
   const [clientId, setClientId] = useState('')
   const [clientSecret, setClientSecret] = useState('')
-  const [callbackError, setCallbackError] = useState<string | null>(null)
-
-  useEffect(() => {
+  const [callbackError] = useState<string | null>(() => {
     const params = new URLSearchParams(window.location.search)
     const err = params.get('error')
-    if (err) {
-      setCallbackError(decodeURIComponent(err))
+    return err ? decodeURIComponent(err) : null
+  })
+  const [showCredentials, setShowCredentials] = useState(false)
+
+  useEffect(() => {
+    if (window.location.search) {
       window.history.replaceState({}, '', window.location.pathname)
     }
   }, [])
@@ -31,18 +30,19 @@ export function SpotifyConnect() {
   const isConnected = spotify === 'connected'
 
   const disconnect = useCallback(() => {
-    http.delete('/auth/spotify').then(() => invalidateHealth());
-  }, [invalidateHealth]);
+    http.delete('/auth/spotify').then(() => invalidateHealth())
+  }, [invalidateHealth])
+
+  const handleReset = useCallback(() => {
+    reset()
+    setShowCredentials(true)
+  }, [reset])
+
+  const isShowingCredentials = showCredentials || configured === false
 
   return (
-    <section
-      aria-labelledby="spotify-connect-heading"
-      className="flex flex-col gap-4 p-8"
-    >
-      <h2
-        id="spotify-connect-heading"
-        className="text-xl font-semibold text-gray-100"
-      >
+    <section aria-labelledby="spotify-connect-heading" className="flex flex-col gap-4 p-8">
+      <h2 id="spotify-connect-heading" className="text-xl font-semibold text-gray-100">
         Conectar Spotify
       </h2>
 
@@ -68,11 +68,10 @@ export function SpotifyConnect() {
         </div>
       ) : (
         <>
-          {configured === false && (
+          {isShowingCredentials && (
             <div className="flex flex-col gap-3 rounded-md border border-gray-700 p-4">
               <p className="text-sm text-gray-400">
-                Configura tus credenciales de desarrollador de Spotify. Puedes
-                obtenerlas en el{' '}
+                Configura tus credenciales de desarrollador de Spotify. Puedes obtenerlas en el{' '}
                 <a
                   href="https://developer.spotify.com/dashboard"
                   target="_blank"
@@ -82,6 +81,11 @@ export function SpotifyConnect() {
                   Dashboard de Spotify
                 </a>
                 .
+              </p>
+              <p className="text-sm text-amber-300">
+                Importante: agrega{' '}
+                <code className="rounded bg-gray-800 px-1.5 py-0.5 text-xs">{REDIRECT_URI}</code>{' '}
+                como Redirect URI en "Edit Settings" de tu app en el Dashboard de Spotify.
               </p>
               <div className="flex flex-col gap-1">
                 <Label>Client ID</Label>
@@ -109,34 +113,38 @@ export function SpotifyConnect() {
                   Guardar credenciales
                 </Button>
               </div>
-              {setupState === 'error' && setupError && (
-                <FieldError>{setupError}</FieldError>
-              )}
+              {setupState === 'error' && setupError && <FieldError>{setupError}</FieldError>}
+            </div>
+          )}
+
+          {configured === true && !isShowingCredentials && (
+            <div>
+              <Button
+                onClick={handleReset}
+                variant="secondary"
+                disabled={setupState === 'resetting'}
+                loading={setupState === 'resetting'}
+              >
+                Cambiar credenciales
+              </Button>
             </div>
           )}
 
           <p className="text-sm text-gray-400">
-            Inicia sesión con tu cuenta de Spotify para que podamos leer tus
-            playlists y álbumes guardados. Serás redirigido a Spotify para
-            autorizar el acceso.
+            Inicia sesión con tu cuenta de Spotify para que podamos leer tus playlists y álbumes
+            guardados. Serás redirigido a Spotify para autorizar el acceso.
           </p>
           <div className="flex flex-col gap-2">
             <div>
               <Button
                 onClick={connect}
-                disabled={
-                  configured !== true ||
-                  state === 'starting' ||
-                  state === 'success'
-                }
+                disabled={configured !== true || state === 'starting' || state === 'success'}
                 loading={state === 'starting'}
               >
                 Conectar con Spotify
               </Button>
             </div>
-            {state === 'error' && errorMessage && (
-              <FieldError>{errorMessage}</FieldError>
-            )}
+            {state === 'error' && errorMessage && <FieldError>{errorMessage}</FieldError>}
           </div>
         </>
       )}


### PR DESCRIPTION
﻿## Summary

- Added DELETE /api/auth/spotify/setup endpoint to clear credentials without touching the token cache
- Added reset() to useSpotifySetup hook to call the new endpoint from the frontend
- Show "Cambiar credenciales" button when credentials exist but Spotify is not connected
- Display redirect URI hint (http://127.0.0.1:5173/api/auth/spotify/callback) in the credentials form
- Fixed pre-existing setState-in-effect lint warning in Spotify.tsx

## Closes

Closes #88

## Test plan

- [x] pytest from backend green (108 passed)
- [x] pnpm test:run in frontend green (257 passed)
- [x] pnpm lint in frontend green (0 errors)
- [x] pnpm format:check on changed files green
- [x] pnpm build in frontend green
- [x] Manual: enter invalid credentials, connect (fail), restart, verify "Cambiar credenciales" appears and allows re-entry
