### PR TITLE
feat(reports): add delete button for migration reports

### DIFF
--- a/backend/src/spotify_to_ytmusic/api/routes/reports.py
+++ b/backend/src/spotify_to_ytmusic/api/routes/reports.py
@@ -4,11 +4,12 @@ from fastapi import APIRouter, HTTPException, status
 from spotify_to_ytmusic.api.models import (
     AlbumMigrationResultResponse,
     MissingItemResponse,
+    OkResponse,
     PlaylistMigrationResultResponse,
     ReportDetailResponse,
     ReportSummaryResponse,
 )
-from spotify_to_ytmusic.core.report import list_reports, load_report
+from spotify_to_ytmusic.core.report import delete_report, list_reports, load_report
 
 router = APIRouter(prefix="/api")
 
@@ -56,3 +57,14 @@ async def get_report(report_id: str) -> ReportDetailResponse:
             detail={"message": f"Report '{report_id}' not found"},
         )
     return _to_report_summary_response(report)
+
+
+@router.delete("/reports/{report_id}", status_code=status.HTTP_200_OK)
+async def delete_report_endpoint(report_id: str) -> OkResponse:
+    deleted = delete_report(report_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"message": f"Report '{report_id}' not found"},
+        )
+    return OkResponse(ok=True)

--- a/backend/src/spotify_to_ytmusic/core/report.py
+++ b/backend/src/spotify_to_ytmusic/core/report.py
@@ -67,6 +67,15 @@ def load_report(report_id: str, directory: Path | str | None = None) -> Migratio
     return _parse_report(data, report_id)
 
 
+def delete_report(report_id: str, directory: Path | str | None = None) -> bool:
+    target_dir = Path(directory) if directory is not None else DATA_DIR
+    path = target_dir / f"migration_report_{report_id}.json"
+    if not path.exists():
+        return False
+    path.unlink()
+    return True
+
+
 def _parse_report(data: dict, report_id: str) -> MigrationReport:
     return MigrationReport(
         id=report_id,

--- a/backend/tests/api/test_reports.py
+++ b/backend/tests/api/test_reports.py
@@ -1,4 +1,4 @@
-"""Integration tests for /api/reports and /api/reports/:id."""
+"""Integration tests for /api/reports, /api/reports/:id, and DELETE /api/reports/:id."""
 import json
 from pathlib import Path
 from unittest.mock import patch
@@ -132,6 +132,24 @@ async def test_get_report_by_id(client):
 async def test_get_report_by_id_404(client):
     with patch("spotify_to_ytmusic.api.routes.reports.load_report", return_value=None):
         resp = await client.get("/api/reports/nonexistent")
+        assert resp.status_code == 404
+        data = resp.json()
+        assert "message" in data["detail"]
+
+
+@pytest.mark.asyncio
+async def test_delete_report_returns_200(client):
+    with patch("spotify_to_ytmusic.api.routes.reports.delete_report", return_value=True):
+        resp = await client.delete("/api/reports/20260306_141532")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_delete_report_returns_404(client):
+    with patch("spotify_to_ytmusic.api.routes.reports.delete_report", return_value=False):
+        resp = await client.delete("/api/reports/nonexistent")
         assert resp.status_code == 404
         data = resp.json()
         assert "message" in data["detail"]

--- a/backend/tests/test_report.py
+++ b/backend/tests/test_report.py
@@ -1,4 +1,4 @@
-"""Tests for atomic report writes."""
+"""Tests for atomic report writes and delete_report."""
 import json
 from pathlib import Path
 from unittest.mock import patch
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from spotify_to_ytmusic.core.models import MigrationReport
-from spotify_to_ytmusic.core.report import save_report
+from spotify_to_ytmusic.core.report import delete_report, save_report
 
 
 def _empty_report() -> MigrationReport:
@@ -51,3 +51,31 @@ def test_save_report_cleans_orphan_tmp(tmp_path: Path):
     save_report(report, directory=tmp_path)
 
     assert not orphan.exists()
+
+
+class TestDeleteReport:
+    def test_delete_existing_report(self, tmp_path: Path):
+        report_id = "20250101_000000"
+        path = tmp_path / f"migration_report_{report_id}.json"
+        path.write_text(json.dumps({"playlists": [], "albums": [], "not_found": []}))
+
+        assert path.exists()
+        result = delete_report(report_id, directory=tmp_path)
+
+        assert result is True
+        assert not path.exists()
+
+    def test_delete_nonexistent_report(self, tmp_path: Path):
+        result = delete_report("nonexistent", directory=tmp_path)
+        assert result is False
+
+    def test_delete_idempotent(self, tmp_path: Path):
+        report_id = "20250101_000000"
+        path = tmp_path / f"migration_report_{report_id}.json"
+        path.write_text(json.dumps({"playlists": [], "albums": [], "not_found": []}))
+
+        first = delete_report(report_id, directory=tmp_path)
+        second = delete_report(report_id, directory=tmp_path)
+
+        assert first is True
+        assert second is False

--- a/frontend/src/features/reports/useDeleteReport.test.ts
+++ b/frontend/src/features/reports/useDeleteReport.test.ts
@@ -1,0 +1,46 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { makeQueryWrapper } from '@/test/queryWrapper';
+import { useDeleteReport } from './useDeleteReport';
+import { server } from '@/test/msw/server';
+import { http, HttpResponse } from 'msw';
+
+describe('useDeleteReport', () => {
+  it('deletes a report successfully', async () => {
+    const { result } = renderHook(() => useDeleteReport(), {
+      wrapper: makeQueryWrapper(),
+    });
+
+    expect(result.current.isIdle).toBe(true);
+
+    act(() => {
+      result.current.mutate('rep_1');
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.ok).toBe(true);
+  });
+
+  it('handles delete error', async () => {
+    server.use(
+      http.delete('*/api/reports/:id', () =>
+        HttpResponse.json({ message: 'Not found' }, { status: 404 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useDeleteReport(), {
+      wrapper: makeQueryWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate('nonexistent');
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});

--- a/frontend/src/features/reports/useDeleteReport.ts
+++ b/frontend/src/features/reports/useDeleteReport.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { http } from '@/lib/http';
+
+interface OkResponse {
+  ok: boolean;
+}
+
+export function useDeleteReport() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => http.delete<OkResponse>(`/reports/${id}`),
+    onSuccess: (_data, id) => {
+      queryClient.invalidateQueries({ queryKey: ['reports'] });
+      queryClient.invalidateQueries({ queryKey: ['reports', id] });
+    },
+  });
+}

--- a/frontend/src/pages/Reports/Detail.test.tsx
+++ b/frontend/src/pages/Reports/Detail.test.tsx
@@ -107,6 +107,38 @@ describe('ReportDetail', () => {
     });
   });
 
+  it('shows delete button', async () => {
+    renderDetail({ onClose: vi.fn() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Eliminar reporte')).toBeInTheDocument();
+    });
+  });
+
+  it('calls delete and onClose on delete button click', async () => {
+    const onClose = vi.fn();
+    let deleteCalled = false;
+    server.use(
+      http.delete('*/api/reports/:id', () => {
+        deleteCalled = true;
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    renderDetail({ onClose, onDownload: vi.fn() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Eliminar reporte')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Eliminar reporte'));
+
+    await waitFor(() => {
+      expect(deleteCalled).toBe(true);
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+  });
+
   it('shows empty messages when sections are empty', async () => {
     const emptyReport = { id: 'empty', playlists: [], albums: [], notFound: [] };
     server.use(

--- a/frontend/src/pages/Reports/Detail.tsx
+++ b/frontend/src/pages/Reports/Detail.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { Card, CardBody, EmptyState, Skeleton } from '@/components/ui';
 import { useReport } from '@/features/reports/useReport';
+import { useDeleteReport } from '@/features/reports/useDeleteReport';
 import { useFocusTrap } from '@/hooks/useFocusTrap';
 import { useAutoFocusHeading } from '@/hooks/useAutoFocusHeading';
 import type { MigrationReport } from '@/types/api';
@@ -32,6 +33,7 @@ export function ReportDetail({ report, onClose, onDownload }: ReportDetailProps)
   const headingRef = useAutoFocusHeading<HTMLHeadingElement>();
   const { data, isLoading, error } = useReport(id);
   const resolved = data ?? report;
+  const deleteMutation = useDeleteReport();
 
   return (
     <div ref={containerRef} className="flex flex-col gap-4" aria-busy={isLoading}>
@@ -53,6 +55,18 @@ export function ReportDetail({ report, onClose, onDownload }: ReportDetailProps)
               Descargar JSON
             </button>
           )}
+          <button
+            type="button"
+            onClick={() => {
+              deleteMutation.mutate(id, {
+                onSuccess: () => onClose(),
+              });
+            }}
+            disabled={deleteMutation.isPending}
+            className="px-3 py-1.5 text-sm font-medium text-red-400 border border-red-800 rounded-md hover:bg-red-900/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 disabled:opacity-50"
+          >
+            {deleteMutation.isPending ? 'Eliminando...' : 'Eliminar reporte'}
+          </button>
           <button
             type="button"
             onClick={onClose}

--- a/frontend/src/pages/Reports/List.test.tsx
+++ b/frontend/src/pages/Reports/List.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { makeQueryWrapper } from '@/test/queryWrapper';
 import { ReportsList } from './List';
@@ -63,5 +63,53 @@ describe('ReportsList', () => {
     expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({
       id: sampleReport.id,
     }));
+  });
+
+  it('shows delete button on each report', async () => {
+    render(<ReportsList />, { wrapper: makeQueryWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Reporte/)).toBeInTheDocument();
+    });
+
+    const deleteButton = screen.getByRole('button', { name: /Eliminar reporte/ });
+    expect(deleteButton).toBeInTheDocument();
+  });
+
+  it('deletes report on delete button click', async () => {
+    let deleteCalled = false;
+    server.use(
+      http.delete('*/api/reports/:id', () => {
+        deleteCalled = true;
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    render(<ReportsList />, { wrapper: makeQueryWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Reporte/)).toBeInTheDocument();
+    });
+
+    const deleteButton = screen.getByRole('button', { name: /Eliminar reporte/ });
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(deleteCalled).toBe(true);
+    });
+  });
+
+  it('delete button does not trigger onSelectReport', async () => {
+    const onSelect = vi.fn();
+    render(<ReportsList onSelectReport={onSelect} />, { wrapper: makeQueryWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Reporte/)).toBeInTheDocument();
+    });
+
+    const deleteButton = screen.getByRole('button', { name: /Eliminar reporte/ });
+    fireEvent.click(deleteButton);
+
+    expect(onSelect).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/Reports/List.tsx
+++ b/frontend/src/pages/Reports/List.tsx
@@ -1,4 +1,5 @@
 import { useReports } from '@/features/reports/useReports';
+import { useDeleteReport } from '@/features/reports/useDeleteReport';
 import { Card, CardBody, EmptyState, Skeleton } from '@/components/ui';
 import type { MigrationReport } from '@/types/api';
 
@@ -9,40 +10,58 @@ interface ReportsListProps {
 function ReportItem({
   report,
   onClick,
+  onDelete,
+  isDeleting,
 }: {
   report: MigrationReport;
   onClick: () => void;
+  onDelete: () => void;
+  isDeleting: boolean;
 }) {
   const playlistCount = report.playlists.length;
   const albumCount = report.albums.length;
   const missCount = report.notFound.length;
 
   return (
-    <button
-      type="button"
-      className="w-full text-left"
-      onClick={onClick}
-    >
-      <Card className="hover:border-blue-300 transition-colors cursor-pointer">
-        <CardBody>
-          <div className="flex items-center justify-between">
-            <div className="flex flex-col gap-1">
-              <span className="text-sm font-medium text-gray-100">
-                {report.id ? `Reporte ${report.id.slice(0, 8)}` : 'Reporte sin ID'}
-              </span>
-              <div className="flex gap-3 text-xs text-gray-400">
-                <span>{playlistCount} playlist{playlistCount !== 1 ? 's' : ''}</span>
-                <span>{albumCount} álbum{albumCount !== 1 ? 'es' : ''}</span>
-                {missCount > 0 && (
-                  <span className="text-red-600">{missCount} no encontrad{missCount !== 1 ? 'as' : 'a'}</span>
-                )}
+    <div className="flex items-center gap-2 group">
+      <button
+        type="button"
+        className="flex-1 w-full text-left"
+        onClick={onClick}
+      >
+        <Card className="hover:border-blue-300 transition-colors cursor-pointer">
+          <CardBody>
+            <div className="flex items-center justify-between">
+              <div className="flex flex-col gap-1">
+                <span className="text-sm font-medium text-gray-100">
+                  {report.id ? `Reporte ${report.id.slice(0, 8)}` : 'Reporte sin ID'}
+                </span>
+                <div className="flex gap-3 text-xs text-gray-400">
+                  <span>{playlistCount} playlist{playlistCount !== 1 ? 's' : ''}</span>
+                  <span>{albumCount} álbum{albumCount !== 1 ? 'es' : ''}</span>
+                  {missCount > 0 && (
+                    <span className="text-red-600">{missCount} no encontrad{missCount !== 1 ? 'as' : 'a'}</span>
+                  )}
+                </div>
               </div>
+              <span className="text-gray-400">→</span>
             </div>
-            <span className="text-gray-400">→</span>
-          </div>
-        </CardBody>
-      </Card>
-    </button>
+          </CardBody>
+        </Card>
+      </button>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete();
+        }}
+        disabled={isDeleting}
+        className="px-2 py-1 text-xs font-medium text-red-400 border border-red-800 rounded-md hover:bg-red-900/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 disabled:opacity-50 disabled:cursor-not-allowed opacity-0 group-hover:opacity-100 transition-opacity"
+        aria-label={`Eliminar reporte ${report.id ?? ''}`}
+      >
+        {isDeleting ? '...' : 'Eliminar'}
+      </button>
+    </div>
   );
 }
 
@@ -65,6 +84,7 @@ function SkeletonList() {
 
 export function ReportsList({ onSelectReport }: ReportsListProps) {
   const { data, isLoading, error } = useReports();
+  const deleteMutation = useDeleteReport();
 
   if (isLoading) {
     return (
@@ -100,6 +120,8 @@ export function ReportsList({ onSelectReport }: ReportsListProps) {
           key={report.id ?? `report-${idx}`}
           report={report}
           onClick={() => onSelectReport?.(report)}
+          onDelete={() => deleteMutation.mutate(report.id ?? '')}
+          isDeleting={deleteMutation.isPending && deleteMutation.variables === report.id}
         />
       ))}
     </div>

--- a/frontend/src/test/msw/handlers.ts
+++ b/frontend/src/test/msw/handlers.ts
@@ -32,6 +32,8 @@ export const handlers = [
     HttpResponse.json({ ...sampleReport, id: params.id as string }),
   ),
 
+  http.delete('*/api/reports/:id', () => HttpResponse.json({ ok: true })),
+
   migrationEvents.addEventListener('connection', ({ client }) => {
     let i = 0;
     const interval = setInterval(() => {


### PR DESCRIPTION
## Summary

- Backend: Added `delete_report()` in `core/report.py` and `DELETE /api/reports/:id` endpoint returning `OkResponse` or 404
- Frontend: Added `useDeleteReport` TanStack Query mutation hook that calls the DELETE endpoint and invalidates the reports cache
- Frontend: Delete button on each report card in the list (appears on hover, stopPropagation prevents navigation)
- Frontend: "Eliminar reporte" button on the detail view that closes after successful deletion
- MSW: Added DELETE handler returning `{ ok: true }`
- Tests: Unit tests for `delete_report` (exists, not exists, idempotent) and integration tests for DELETE endpoint (200, 404)
- Tests: Hook tests for `useDeleteReport` (success, error) and UI tests for delete buttons in List and Detail

## Closes

Closes #90

## Test plan

- [x] `pytest` from `backend/` in green (113 passed)
- [x] `pnpm test:run` in `frontend/` in green (264 passed)
- [x] `pnpm lint` in `frontend/` in green (no errors)
- [x] `pnpm build` in `frontend/` in green (tsc + vite build)
- [x] Verification manual: Start the API server and call `DELETE /api/reports/:id`, verify the JSON file is removed
