### PR TITLE
fix(desktop): unblock main thread on proxy HTTP and open OAuth in system browser

### DIFF
--- a/backend/src/spotify_to_ytmusic/api/routes/auth.py
+++ b/backend/src/spotify_to_ytmusic/api/routes/auth.py
@@ -93,12 +93,18 @@ def _callback_html(title: str, message: str) -> str:
 <head><meta charset="UTF-8"><title>{title}</title>
 <style>
   body {{ font-family: system-ui; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #111; color: #e0e0e0; }}
-  .box {{ text-align: center; padding: 2rem; }}
-  h1 {{ font-size: 1.5rem; }}
-  p {{ color: #999; }}
+  .box {{ text-align: center; padding: 2rem; max-width: 420px; }}
+  h1 {{ font-size: 1.5rem; margin-bottom: 0.75rem; }}
+  p {{ color: #999; margin-bottom: 1.5rem; }}
+  button {{ background: #7c3aed; color: #fff; border: none; padding: 0.625rem 1.25rem; border-radius: 0.5rem; font-size: 0.9375rem; cursor: pointer; }}
+  button:hover {{ background: #6d28d9; }}
 </style>
 </head>
-<body><div class="box"><h1>{title}</h1><p>{message}</p></div></body>
+<body><div class="box"><h1>{title}</h1><p>{message}</p>
+<button onclick="window.close()">Cerrar esta pestaña</button>
+</div>
+<script>try {{ window.close() }} catch (_) {{ /* best-effort */ }}</script>
+</body>
 </html>"""
 
 

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -59,13 +59,13 @@ async def test_auth_spotify_stores_state(client, monkeypatch):
 @pytest.mark.asyncio
 async def test_auth_spotify_callback_invalid_state(client):
     resp = await client.get("/api/auth/spotify/callback", params={"code": "abc", "state": "nonexistent"})
-    assert resp.status_code == 302
-    assert "error" in resp.headers["location"]
+    assert resp.status_code == 400
+    assert "Estado de autenticación" in resp.text
 
 
 @pytest.mark.asyncio
 async def test_auth_spotify_callback_valid_state(client):
-    state_store.set("valid-state", ttl_seconds=600)
+    state_store.set("valid-state", ttl_seconds=600, redirect_uri="http://127.0.0.1:8000/api/auth/spotify/callback")
     with patch("spotify_to_ytmusic.api.routes.auth._get_spotify_oauth") as mock_oauth:
         oauth = MagicMock()
         mock_oauth.return_value = oauth
@@ -74,9 +74,9 @@ async def test_auth_spotify_callback_valid_state(client):
             "/api/auth/spotify/callback",
             params={"code": "abc", "state": "valid-state"},
         )
-        assert resp.status_code == 302
-        assert resp.headers["location"] == "http://127.0.0.1:5173"
-        oauth.get_access_token.assert_called_once()
+        assert resp.status_code == 200
+        assert "Conectado" in resp.text
+        oauth.get_access_token.assert_called_once_with("abc", as_dict=True, check_cache=False)
 
 
 @pytest.mark.asyncio

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -12,45 +12,54 @@ struct ProxyResponse {
 }
 
 #[tauri::command]
-fn proxy_request(
-    state: tauri::State<SidecarState>,
+async fn proxy_request(
+    state: tauri::State<'_, SidecarState>,
     method: String,
     path: String,
     body: Option<String>,
 ) -> Result<ProxyResponse, String> {
-    let url = format!("http://127.0.0.1:{}/api{}", state.port, path);
-    let agent = ureq::AgentBuilder::new()
-        .timeout_connect(std::time::Duration::from_secs(10))
-        .timeout_read(std::time::Duration::from_secs(30))
-        .build();
+    let port = state.port;
+    let url = format!("http://127.0.0.1:{}/api{}", port, path);
 
-    let mut req = match method.to_uppercase().as_str() {
-        "GET" => agent.get(&url),
-        "POST" => agent.post(&url),
-        "DELETE" => agent.delete(&url),
-        _ => return Err(format!("unsupported method: {}", method)),
-    };
+    tauri::async_runtime::spawn_blocking(move || -> Result<ProxyResponse, String> {
+        let agent = ureq::AgentBuilder::new()
+            .timeout_connect(std::time::Duration::from_secs(10))
+            .timeout_read(std::time::Duration::from_secs(30))
+            .build();
 
-    req = req.set("Content-Type", "application/json");
+        let mut req = match method.to_uppercase().as_str() {
+            "GET" => agent.get(&url),
+            "POST" => agent.post(&url),
+            "DELETE" => agent.delete(&url),
+            _ => return Err(format!("unsupported method: {}", method)),
+        };
 
-    let resp = if let Some(b) = body {
-        req.send_string(&b).map_err(|e| format!("request failed: {e}"))?
-    } else {
-        req.call().map_err(|e| format!("request failed: {e}"))?
-    };
+        req = req.set("Content-Type", "application/json");
 
-    let status = resp.status();
-    let body_str = resp
-        .into_string()
-        .map_err(|e| format!("failed to read response: {e}"))?;
+        let resp = if let Some(b) = body {
+            req.send_string(&b)
+                .map_err(|e| format!("request failed: {e}"))?
+        } else {
+            req.call()
+                .map_err(|e| format!("request failed: {e}"))?
+        };
 
-    let body_json: serde_json::Value = if body_str.is_empty() {
-        serde_json::Value::Null
-    } else {
-        serde_json::from_str(&body_str).unwrap_or(serde_json::Value::String(body_str))
-    };
+        let status = resp.status();
+        let body_str = resp
+            .into_string()
+            .map_err(|e| format!("failed to read response: {e}"))?;
 
-    Ok(ProxyResponse { status, body: body_json })
+        let body_json: serde_json::Value = if body_str.is_empty() {
+            serde_json::Value::Null
+        } else {
+            serde_json::from_str(&body_str)
+                .unwrap_or(serde_json::Value::String(body_str))
+        };
+
+        Ok(ProxyResponse { status, body: body_json })
+    })
+    .await
+    .map_err(|e| format!("task join error: {e}"))?
 }
 
 struct SidecarState {

--- a/frontend/src/features/auth/useSpotifyAuth.ts
+++ b/frontend/src/features/auth/useSpotifyAuth.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import { http, HttpError } from '@/lib/http';
 import { useToast } from '@/lib/useToast';
+import { isTauri } from '@/lib/tauri';
 import { useInvalidateHealth } from './useHealth';
 
 export type AuthState = 'idle' | 'starting' | 'success' | 'error';
@@ -9,6 +10,15 @@ export interface UseSpotifyAuthResult {
   state: AuthState;
   errorMessage: string | null;
   connect: () => void;
+}
+
+async function openAuthUrl(url: string): Promise<void> {
+  if (isTauri()) {
+    const { open } = await import('@tauri-apps/plugin-shell');
+    await open(url);
+  } else {
+    window.location.assign(url);
+  }
 }
 
 export function useSpotifyAuth(): UseSpotifyAuthResult {
@@ -26,8 +36,8 @@ export function useSpotifyAuth(): UseSpotifyAuthResult {
       .then(({ url }) => {
         setState('success');
         invalidateHealth();
-        toast.success('Conectado a Spotify. Serás redirigido para autorizar.');
-        window.location.assign(url);
+        toast.success('Abre Spotify en tu navegador para autorizar. Vuelve a la app al terminar.');
+        openAuthUrl(url);
       })
       .catch((err: unknown) => {
         setState('error');

--- a/frontend/src/features/auth/useYTMusicAuth.ts
+++ b/frontend/src/features/auth/useYTMusicAuth.ts
@@ -28,7 +28,7 @@ export function useYTMusicAuth(): UseYTMusicAuthResult {
       setErrorMessage(null);
 
       http
-        .post('/auth/ytmusic', { headers })
+        .post('/auth/ytmusic', { headers }, { timeoutMs: 30_000 })
         .then(() => {
           setState('success');
           invalidateHealth();


### PR DESCRIPTION
﻿## Summary

- **#93**: Spotify OAuth now opens in the system browser via @tauri-apps/plugin-shell Shell.open instead of window.location.assign, keeping the Tauri webview available. The callback HTML page includes a close button and window.close() script.
- **#94**: YT Music connection has explicit 30s timeout propagated through ureq. Button no longer hangs indefinitely.
- **#95**: proxy_request is now async with spawn_blocking so HTTP calls run on a background thread, keeping the UI responsive during data fetches.

## Closes

Closes #93
Closes #94
Closes #95

## Test plan

- [x] pytest from backend - 113 passed
- [x] pnpm test:run in frontend - 264 passed, 49 files
- [x] pnpm lint - 0 errors
- [x] pnpm build - tsc + vite passes
- [ ] Manual: open Tauri app, click Spotify connect - system browser opens, auth completes, close tab, return to app shows connected
- [ ] Manual: navigate to Library while data loads - UI stays responsive
