### PR TITLE
fix(desktop): YT Music auth with x-goog-authuser and reliable sidecar cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,10 +109,11 @@ wraps `ytmusicapi` with retry/backoff. `TrackCache` persists
   Rust `ureq` → sidecar. The WebView2 browser blocks `fetch` from
   `tauri://localhost` to `http://127.0.0.1` (CORS/security). The IPC proxy
   bypasses this entirely. Never use raw `fetch` in desktop-mode features.
-- **Tauri sync commands run on the MAIN THREAD.** `proxy_request` is a
-  `#[tauri::command] fn` (sync) → `ureq` blocks the main thread for up to
-  30 s. During HTTP calls the entire webview is frozen. Future fix: make it
-  `async fn` with `spawn_blocking`. Until then, keep sidecar requests fast.
+- **Tauri HTTP is async now.** `proxy_request` is `async fn` and uses
+  `spawn_blocking` so `ureq` calls run on a background thread. The main
+  thread is never blocked during HTTP. `timeoutMs` from `http.ts` is
+  propagated via `Promise.race` + `AbortController` (the Rust side also
+  has `timeout_read(30s)` as a fallback).
 - **Sidecar port is fixed at 53000** (outside Windows ephemeral range
   49152-65535). Using a port inside that range causes `WinError 10013`
   (WSAEACCES). The OAuth redirect URI must match: register
@@ -123,7 +124,9 @@ wraps `ytmusicapi` with retry/backoff. `TrackCache` persists
   defaults to `./data` relative to its CWD (somewhere in Program Files,
   unwritable). Credentials, cache, and reports are stored here.
 - **Sidecar cleanup on exit.** The `child` process handle is stored in
-  `SidecarState` and killed via `RunEvent::Exit` in `.run()` callback.
+  `SidecarState` and killed via `RunEvent::Exit` in `.run()` callback
+  with `eprintln!` logging at every failure point. `kill()` is followed
+  by `wait()` to ensure the process has exited before Tauri terminates.
   Don't spawn the child without storing a reference to kill it.
 - **`build_sidecar.py` copies a ONE-FILE binary.** The PyInstaller spec
   (`--onefile`) produces `dist/spotify-to-ytmusic-server.exe` directly (no
@@ -140,13 +143,18 @@ wraps `ytmusicapi` with retry/backoff. `TrackCache` persists
 - **Updater plugin** requires `TAURI_SIGNING_PRIVATE_KEY` and
   `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` secrets configured in the repo.
   The pubkey lives in `tauri.conf.json` under `plugins.updater.pubkey`.
-- **Spotify OAuth callback** returns an HTML page (not a redirect) because
-  the Tauri frontend port is unknown at callback time. The user must
-  manually return to the app. Future: use `shell.open()` to open Spotify
-  in the system browser instead of navigating the webview away.
-- **YT Music auth (`POST /api/auth/ytmusic`)** calls
-  `ytmusicapi.setup_browser()` which may block or hang. Avoid calling it
-  from a sync Tauri command without a timeout guard.
+- **Spotify OAuth callback** returns an HTML page (not a redirect). The
+  frontend uses `shell.open()` to open Spotify in the system browser so
+  the Tauri webview stays on the app. After authenticating, the user
+  closes the browser tab (the callback page has a close button) and
+  returns to the Tauri app.
+- **YT Music auth (`POST /api/auth/ytmusic`)** requires the `x-goog-authuser`
+  header in addition to `cookie` and `user-agent`. The endpoint validates
+  all three before calling `ytmusicapi.setup_browser()` and wraps the call
+  in `try`/`except` to surface `YTMusicUserError` as a validation message.
+  `setup_browser()` in ytmusicapi >= 1.10 is a local-only operation (no
+  network calls). The frontend reads errors from both `body.message` and
+  `body.detail` (FastAPI fallback).
 - **Credenciales Spotify**: se guardan via UI en `spotify_credentials.json`.
   El `.env` solo sirve para la CLI.
 

--- a/backend/src/spotify_to_ytmusic/api/routes/auth.py
+++ b/backend/src/spotify_to_ytmusic/api/routes/auth.py
@@ -114,6 +114,7 @@ async def auth_ytmusic(body: dict) -> OkResponse | ErrorResponse:
     if not isinstance(headers, str) or not headers.strip():
         return ErrorResponse(message="Pega los headers del navegador antes de continuar.")
     from ytmusicapi.auth.browser import setup_browser
+    from ytmusicapi.exceptions import YTMusicUserError
     from spotify_to_ytmusic.core.headers_parser import normalize_headers
 
     normalized = normalize_headers(headers)
@@ -124,7 +125,17 @@ async def auth_ytmusic(body: dict) -> OkResponse | ErrorResponse:
         return ErrorResponse(
             message="Los headers deben incluir al menos cookie: y user-agent:."
         )
-    setup_browser(filepath=BROWSER_AUTH_FILE, headers_raw=normalized)
+    if "x-goog-authuser:" not in lower:
+        return ErrorResponse(
+            message='Falta el header x-goog-authuser. Copia los headers de una petición /browse '
+                    'en la pestaña Network de DevTools (F12) y asegúrate de incluir este header.'
+        )
+    try:
+        setup_browser(filepath=BROWSER_AUTH_FILE, headers_raw=normalized)
+    except YTMusicUserError as e:
+        return ErrorResponse(message=f"Error en los headers: {e}")
+    except Exception as e:
+        return ErrorResponse(message=f"No se pudo conectar con YouTube Music: {e}")
     return OkResponse(ok=True)
 
 

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -86,12 +86,25 @@ async def test_auth_ytmusic_valid_headers(client, tmp_path):
          patch("ytmusicapi.auth.browser.setup_browser") as mock_setup:
         resp = await client.post(
             "/api/auth/ytmusic",
-            json={"headers": "cookie: ABC\nuser-agent: Mozilla/5.0"},
+            json={
+                "headers": "cookie: ABC\nuser-agent: Mozilla/5.0\nx-goog-authuser: 1"
+            },
         )
         assert resp.status_code == 200
         data = resp.json()
         assert data["ok"] is True
         mock_setup.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_auth_ytmusic_missing_x_goog_authuser(client):
+    resp = await client.post(
+        "/api/auth/ytmusic",
+        json={"headers": "cookie: ABC\nuser-agent: Mozilla/5.0"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "x-goog-authuser" in data["message"].lower()
 
 
 @pytest.mark.asyncio

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spotify-to-ytmusic"
-version = "0.2.1"
+version = "0.2.2"
 description = "Migrate your Spotify library to YouTube Music"
 authors = ["vsrd-sftw"]
 edition = "2021"

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -2,7 +2,7 @@ use std::sync::Mutex;
 
 use serde::Serialize;
 use tauri::Manager;
-use tauri_plugin_shell::process::CommandEvent;
+use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
 
 #[derive(Serialize)]
@@ -64,12 +64,29 @@ async fn proxy_request(
 
 struct SidecarState {
     port: u16,
-    child: Mutex<Option<tauri_plugin_shell::process::CommandChild>>,
+    child: Mutex<Option<CommandChild>>,
 }
 
 #[tauri::command]
 fn get_server_port(state: tauri::State<SidecarState>) -> u16 {
     state.port
+}
+
+fn kill_sidecar(child: &mut Option<CommandChild>) {
+    if let Some(c) = child.take() {
+        eprintln!("[sidecar] killing sidecar process…");
+        if let Err(e) = c.kill() {
+            eprintln!("[sidecar] kill() failed: {e}");
+        } else {
+            eprintln!("[sidecar] kill() sent, waiting for process exit…");
+            match c.wait() {
+                Ok(status) => eprintln!("[sidecar] process exited with {status}"),
+                Err(e) => eprintln!("[sidecar] wait() failed: {e}"),
+            }
+        }
+    } else {
+        eprintln!("[sidecar] no child to kill (already taken or never set)");
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -98,12 +115,12 @@ pub fn run() {
         .expect("error while building tauri application")
         .run(|app_handle, event| {
             if let tauri::RunEvent::Exit = event {
-                if let Some(state) = app_handle.try_state::<SidecarState>() {
-                    if let Ok(mut child) = state.child.lock() {
-                        if let Some(c) = child.take() {
-                            let _ = c.kill();
-                        }
-                    }
+                match app_handle.try_state::<SidecarState>() {
+                    Some(state) => match state.child.lock() {
+                        Ok(mut child) => kill_sidecar(&mut child),
+                        Err(e) => eprintln!("[sidecar] mutex poisoned, cannot kill sidecar: {e}"),
+                    },
+                    None => eprintln!("[sidecar] SidecarState not found, cannot kill sidecar"),
                 }
             }
         });
@@ -124,24 +141,28 @@ async fn spawn_sidecar(app: &tauri::AppHandle) -> Result<u16, Box<dyn std::error
         .spawn()
         .map_err(|e| format!("failed to spawn sidecar: {e}"))?;
 
-    let port: u16;
-    loop {
+    let port: u16 = loop {
         match rx.recv().await {
             Some(CommandEvent::Stdout(line)) => {
                 let text = String::from_utf8_lossy(&line);
                 if let Some(p) = text.trim().strip_prefix("SERVER_LISTENING port=") {
-                    port = p
-                        .parse()
-                        .map_err(|_| format!("invalid SERVER_LISTENING line: {text}"))?;
-                    break;
+                    match p.parse() {
+                        Ok(port) => break port,
+                        Err(_) => {
+                            eprintln!("[sidecar] invalid SERVER_LISTENING line: {text}");
+                        }
+                    }
                 }
             }
             Some(CommandEvent::Terminated(_)) | None => {
+                eprintln!("[sidecar] sidecar exited prematurely — killing before returning error");
+                let _ = child.kill();
+                let _ = child.wait();
                 return Err("sidecar exited without printing SERVER_LISTENING".into());
             }
             _ => {}
         }
-    }
+    };
 
     app.manage(SidecarState {
         port,

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicknaming/Tauri-2.0/refs/heads/main/schema/config.schema.json",
   "productName": "Spotify to YT Music",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "com.spotify-to-ytmusic.app",
   "build": {
     "frontendDist": "../dist",

--- a/frontend/src/features/auth/useYTMusicAuth.ts
+++ b/frontend/src/features/auth/useYTMusicAuth.ts
@@ -11,6 +11,14 @@ export interface UseYTMusicAuthResult {
   connect: (headers: string) => void;
 }
 
+function extractErrorMessage(err: HttpError): string | null {
+  const body = err.body as Record<string, unknown> | null;
+  if (typeof body?.message === 'string') return body.message;
+  if (typeof body?.detail === 'string') return body.detail;
+  if (typeof body === 'string') return body;
+  return null;
+}
+
 export function useYTMusicAuth(): UseYTMusicAuthResult {
   const [state, setState] = useState<AuthState>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -37,12 +45,8 @@ export function useYTMusicAuth(): UseYTMusicAuthResult {
         .catch((err: unknown) => {
           setState('error');
           if (err instanceof HttpError) {
-            const body = err.body as Record<string, unknown> | null;
-            setErrorMessage(
-              typeof body?.message === 'string'
-                ? body.message
-                : `Error al conectar con YouTube Music (${err.status})`,
-            );
+            const detail = extractErrorMessage(err);
+            setErrorMessage(detail ?? `Error al conectar con YouTube Music (${err.status})`);
           } else {
             setErrorMessage('No se pudo conectar. Comprueba tu conexión e inténtalo de nuevo.');
           }

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -23,17 +23,38 @@ interface ProxyResponse {
   body: unknown
 }
 
-async function tauriRequest<T>(method: string, path: string, bodyStr?: string): Promise<T> {
+async function tauriRequest<T>(method: string, path: string, bodyStr?: string, timeoutMs?: number): Promise<T> {
   const { invoke } = await import('@tauri-apps/api/core')
-  const resp: ProxyResponse = await invoke('proxy_request', {
-    method,
-    path: path.startsWith('/') ? path : `/${path}`,
-    body: bodyStr ?? null,
-  })
-  if (resp.status < 200 || resp.status >= 300) {
-    throw new HttpError(resp.status, resp.body)
+  const controller = new AbortController()
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+  if (timeoutMs && timeoutMs > 0) {
+    timer = setTimeout(() => controller.abort(), timeoutMs)
   }
-  return resp.body as T
+
+  try {
+    const invokePromise = invoke('proxy_request', {
+      method,
+      path: path.startsWith('/') ? path : `/${path}`,
+      body: bodyStr ?? null,
+    }) as Promise<ProxyResponse>
+
+    const abortPromise = new Promise<never>((_, reject) => {
+      controller.signal.addEventListener('abort', () =>
+        reject(new HttpError(0, null, `La petición excedió el tiempo de espera (${timeoutMs}ms)`)),
+        { once: true },
+      )
+    })
+
+    const resp = await Promise.race([invokePromise, abortPromise])
+
+    if (resp.status < 200 || resp.status >= 300) {
+      throw new HttpError(resp.status, resp.body)
+    }
+    return resp.body as T
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
 }
 
 async function resolveUrl(path: string): Promise<string> {
@@ -94,19 +115,20 @@ function splitOptions(options?: RequestOptions): {
 
 export const http = {
   get<T>(path: string, options?: RequestOptions): Promise<T> {
-    if (isTauri()) return tauriRequest<T>('GET', path)
     const { init, timeoutMs } = splitOptions(options)
+    if (isTauri()) return tauriRequest<T>('GET', path, undefined, timeoutMs)
     return webRequest<T>(path, { ...init, method: 'GET' }, { timeoutMs })
   },
   post<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> {
+    const { init, timeoutMs } = splitOptions(options)
     if (isTauri()) {
       return tauriRequest<T>(
         'POST',
         path,
         body !== undefined ? JSON.stringify(body) : undefined,
+        timeoutMs,
       )
     }
-    const { init, timeoutMs } = splitOptions(options)
     const headers = new Headers(init.headers)
     if (body !== undefined && !headers.has('content-type')) {
       headers.set('content-type', 'application/json')
@@ -123,8 +145,8 @@ export const http = {
     )
   },
   delete<T>(path: string, options?: RequestOptions): Promise<T> {
-    if (isTauri()) return tauriRequest<T>('DELETE', path)
     const { init, timeoutMs } = splitOptions(options)
+    if (isTauri()) return tauriRequest<T>('DELETE', path, undefined, timeoutMs)
     return webRequest<T>(path, { ...init, method: 'DELETE' }, { timeoutMs })
   },
 }

--- a/frontend/src/pages/Connect/YTMusic.tsx
+++ b/frontend/src/pages/Connect/YTMusic.tsx
@@ -43,11 +43,11 @@ export function YTMusicConnect() {
             Para autenticar con YouTube Music necesitas capturar los headers de tu navegador:
           </p>
           <ol className="list-decimal list-inside space-y-1 text-sm text-gray-400">
-            <li>Abre YouTube Music en Chrome o Firefox.</li>
+            <li>Abre <strong>YouTube Music</strong> en Chrome o Firefox.</li>
             <li>Abre las DevTools (F12) y ve a la pestaña <strong>Network</strong>.</li>
             <li>Recarga la página y filtra las peticiones por <code>browse</code>.</li>
-            <li>Haz clic en cualquier petición a <code>browse</code> y copia los headers de la sección <strong>Request Headers</strong>.</li>
-            <li>Pega los headers en el campo de abajo y pulsa «Conectar».</li>
+            <li>Haz clic en cualquier petición a <code>browse</code> y en la sección <strong>Request Headers</strong> copia el bloque entero (incluye <code>x-goog-authuser</code>, <code>cookie</code> y <code>user-agent</code>).</li>
+            <li>Pega los headers aquí y pulsa «Conectar».</li>
           </ol>
           <div className="flex flex-col gap-1">
             <Label htmlFor="ytmusic-headers">Headers del navegador</Label>


### PR DESCRIPTION
﻿## Summary

- **YT Music auth**: `POST /api/auth/ytmusic` now validates `x-goog-authuser` header (required by ytmusicapi), wraps `setup_browser` in try/except to surface errors as readable messages, and the frontend reads both `body.message` and `body.detail` fields.
- **Timeout propagation**: `timeoutMs` from `http.ts` is now propagated through Tauri IPC proxy via `Promise.race` with `AbortController`, so the 30s timeout works in desktop mode.
- **Sidecar cleanup**: `RunEvent::Exit` handler logs every failure point with `eprintln!`, adds `wait()` after `kill()` to ensure the process has exited, and kills orphaned sidecar if it exits prematurely during startup.
- **Updated user instructions**: YTMusic.tsx now explains that `x-goog-authuser` must be included in the copied headers.
- **CLAUDE.md** updated to reflect current state.

## Closes

Closes #94

## Test plan

- [x] `pytest` from `backend/` — 114 passed
- [x] `pnpm test:run` in `frontend/` — 264 passed, 49 files
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — tsc + vite passes
- [ ] Manual: Paste valid YT Music headers (including `x-goog-authuser`) → connects successfully
- [ ] Manual: Paste headers without `x-goog-authuser` → see descriptive error message
- [ ] Manual: Close Tauri app window → `spotify-to-ytmusic-server.exe` not running in Task Manager
