### PR TITLE
fix(desktop): reliable sidecar cleanup and ytmusic auth feedback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,12 +126,25 @@ wraps `ytmusicapi` with retry/backoff. `TrackCache` persists
 - **Sidecar cleanup on exit.** The `CommandChild` is parked in a
   module-level `OnceLock<Mutex<Option<CommandChild>>>` (NOT in
   `app.manage()`), because Tauri may drop managed state before
-  `RunEvent::Exit` fires. Cleanup is hooked on three events —
-  `RunEvent::ExitRequested`, `RunEvent::Exit`, and
-  `WindowEvent::Destroyed` — and is idempotent via `Option::take()`.
-  The sidecar also runs a daemon thread that polls its parent PID and
-  self-terminates within ~2 s if Tauri crashes; without that watchdog,
-  a hard kill of the host would orphan `spotify-to-ytmusic-server.exe`.
+  `RunEvent::Exit` fires. Cleanup is hooked on `RunEvent::ExitRequested`
+  and `RunEvent::Exit` and is idempotent via `Option::take()`.
+  `WindowEvent::Destroyed` was tried but removed — it could fire during
+  WebView2 startup transitions on some Windows machines and prematurely
+  kill the sidecar. The sidecar also runs a daemon thread that, after
+  a 5 s startup grace, polls its parent PID and self-terminates within
+  ~2 s if Tauri crashes. On Windows the parent-alive probe uses
+  `OpenProcess` + `GetExitCodeProcess` via ctypes — `os.kill(pid, 0)`
+  reports dead processes via `OSError`, NOT `ProcessLookupError`, so
+  the POSIX pattern would treat dead parents as alive.
+- **`pnpm tauri build` does NOT rebuild the sidecar.** Run
+  `python backend/scripts/build_sidecar.py` first; the script now
+  refuses to copy a sidecar binary smaller than 1 MB, but bundling an
+  outdated binary is silent. Always rebuild the sidecar after touching
+  any backend code that ships in the desktop app.
+- **Tauri startup failures pop a native dialog.** `lib.rs` replaces
+  `expect()` on `Builder::build()` with a `match` that logs to stderr,
+  shows `MessageBoxW` with the error, and exits cleanly. This converts
+  silent "blank window then close" launches into actionable bug reports.
 - **`build_sidecar.py` copies a ONE-FILE binary.** The PyInstaller spec
   (`--onefile`) produces `dist/spotify-to-ytmusic-server.exe` directly (no
   subdirectory). The script copies it to `binaries/spotify-to-ytmusic-server-{target-triple}.exe`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,11 +123,15 @@ wraps `ytmusicapi` with retry/backoff. `TrackCache` persists
   sidecar reads this env var in `config.py`. Without it, the sidecar
   defaults to `./data` relative to its CWD (somewhere in Program Files,
   unwritable). Credentials, cache, and reports are stored here.
-- **Sidecar cleanup on exit.** The `child` process handle is stored in
-  `SidecarState` and killed via `RunEvent::Exit` in `.run()` callback
-  with `eprintln!` logging at every failure point. `kill()` calls
-  `TerminateProcess` on Windows. Don't spawn the child without storing
-  a reference to kill it.
+- **Sidecar cleanup on exit.** The `CommandChild` is parked in a
+  module-level `OnceLock<Mutex<Option<CommandChild>>>` (NOT in
+  `app.manage()`), because Tauri may drop managed state before
+  `RunEvent::Exit` fires. Cleanup is hooked on three events —
+  `RunEvent::ExitRequested`, `RunEvent::Exit`, and
+  `WindowEvent::Destroyed` — and is idempotent via `Option::take()`.
+  The sidecar also runs a daemon thread that polls its parent PID and
+  self-terminates within ~2 s if Tauri crashes; without that watchdog,
+  a hard kill of the host would orphan `spotify-to-ytmusic-server.exe`.
 - **`build_sidecar.py` copies a ONE-FILE binary.** The PyInstaller spec
   (`--onefile`) produces `dist/spotify-to-ytmusic-server.exe` directly (no
   subdirectory). The script copies it to `binaries/spotify-to-ytmusic-server-{target-triple}.exe`.
@@ -149,12 +153,16 @@ wraps `ytmusicapi` with retry/backoff. `TrackCache` persists
   closes the browser tab (the callback page has a close button) and
   returns to the Tauri app.
 - **YT Music auth (`POST /api/auth/ytmusic`)** requires the `x-goog-authuser`
-  header in addition to `cookie` and `user-agent`. The endpoint validates
-  all three before calling `ytmusicapi.setup_browser()` and wraps the call
-  in `try`/`except` to surface `YTMusicUserError` as a validation message.
-  `setup_browser()` in ytmusicapi >= 1.10 is a local-only operation (no
-  network calls). The frontend reads errors from both `body.message` and
-  `body.detail` (FastAPI fallback).
+  header in addition to `cookie` and `user-agent`. The endpoint returns
+  proper HTTP status codes (`400` for validation/`YTMusicUserError`,
+  `504` if `setup_browser` exceeds `YTMUSIC_SETUP_TIMEOUT_S`, `500` for
+  unexpected errors); the body is always `{message: str}`. `setup_browser`
+  is dispatched through `loop.run_in_executor` wrapped in
+  `asyncio.wait_for` so a hung call cannot stall the response — the
+  frontend always sees success or an error within seconds. The frontend
+  reads errors from `body.message` / `body.detail`, **and** also treats a
+  `200` response that contains `{message: ...}` as an error (defense
+  against older builds that returned `ErrorResponse` with status 200).
 - **Credenciales Spotify**: se guardan via UI en `spotify_credentials.json`.
   El `.env` solo sirve para la CLI.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,14 @@ wraps `ytmusicapi` with retry/backoff. `TrackCache` persists
   thread is never blocked during HTTP. `timeoutMs` from `http.ts` is
   propagated via `Promise.race` + `AbortController` (the Rust side also
   has `timeout_read(30s)` as a fallback).
+- **`proxy_request` must NOT collapse 4xx/5xx into `Err`.** `ureq` 2.x
+  returns `Err(ureq::Error::Status(code, response))` for every non-2xx
+  status. The Rust side must match that variant and return a normal
+  `ProxyResponse { status, body }` with the JSON payload preserved —
+  otherwise the frontend's `HttpError` path never fires, error toasts
+  never appear, and the user sees a button stuck in `submitting`. Only
+  `ureq::Error::Transport` (no HTTP response at all) should propagate
+  as `Err` to the JS side.
 - **Sidecar port is fixed at 53000** (outside Windows ephemeral range
   49152-65535). Using a port inside that range causes `WinError 10013`
   (WSAEACCES). The OAuth redirect URI must match: register
@@ -123,19 +131,36 @@ wraps `ytmusicapi` with retry/backoff. `TrackCache` persists
   sidecar reads this env var in `config.py`. Without it, the sidecar
   defaults to `./data` relative to its CWD (somewhere in Program Files,
   unwritable). Credentials, cache, and reports are stored here.
-- **Sidecar cleanup on exit.** The `CommandChild` is parked in a
-  module-level `OnceLock<Mutex<Option<CommandChild>>>` (NOT in
-  `app.manage()`), because Tauri may drop managed state before
-  `RunEvent::Exit` fires. Cleanup is hooked on `RunEvent::ExitRequested`
-  and `RunEvent::Exit` and is idempotent via `Option::take()`.
-  `WindowEvent::Destroyed` was tried but removed — it could fire during
-  WebView2 startup transitions on some Windows machines and prematurely
-  kill the sidecar. The sidecar also runs a daemon thread that, after
-  a 5 s startup grace, polls its parent PID and self-terminates within
-  ~2 s if Tauri crashes. On Windows the parent-alive probe uses
-  `OpenProcess` + `GetExitCodeProcess` via ctypes — `os.kill(pid, 0)`
-  reports dead processes via `OSError`, NOT `ProcessLookupError`, so
-  the POSIX pattern would treat dead parents as alive.
+- **Sidecar cleanup on exit.** Three layered defenses, in order of
+  reliability:
+  1. **Win32 Job Object** ([src-tauri/src/job.rs](frontend/src-tauri/src/job.rs)).
+     At startup, `lib.rs` creates a job with
+     `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and assigns the sidecar's PID
+     after spawn. When the host exits — cleanly, via crash, or via Task
+     Manager — the OS itself terminates every process in the job. This
+     is the only mechanism that reliably handles the PyInstaller
+     `--onefile` bootstrap, which leaves a zombie launcher process if
+     the runtime is killed via `TerminateProcess` alone. Requires
+     `windows-sys` features: `Win32_Foundation`, `Win32_Security`,
+     `Win32_System_JobObjects`, `Win32_System_Threading`.
+  2. **`CommandChild::kill()`** on `RunEvent::ExitRequested` and
+     `RunEvent::Exit`. The `CommandChild` is parked in a module-level
+     `OnceLock<Mutex<Option<CommandChild>>>` (NOT in `app.manage()`),
+     because Tauri may drop managed state before `RunEvent::Exit`
+     fires. Cleanup is idempotent via `Option::take()`.
+     `WindowEvent::Destroyed` was tried but removed — it could fire
+     during WebView2 startup transitions on some Windows machines and
+     prematurely kill the sidecar.
+  3. **Parent-watchdog inside the sidecar.** Daemon thread that polls
+     the host PID every 2 s (after a 5 s startup grace) and self-exits
+     via `os._exit(0)` if it disappears. The host PID is passed
+     explicitly as `argv[2]` because `os.getppid()` under PyInstaller
+     `--onefile` returns the bootstrap launcher's PID, not Tauri's, so
+     a `getppid()`-only watchdog would miss host crashes. On Windows
+     the probe uses `OpenProcess` + `GetExitCodeProcess` via ctypes —
+     `os.kill(pid, 0)` reports dead processes via `OSError`, NOT
+     `ProcessLookupError`, so the POSIX pattern would treat dead
+     parents as alive.
 - **`pnpm tauri build` does NOT rebuild the sidecar.** Run
   `python backend/scripts/build_sidecar.py` first; the script now
   refuses to copy a sidecar binary smaller than 1 MB, but bundling an
@@ -152,6 +177,21 @@ wraps `ytmusicapi` with retry/backoff. `TrackCache` persists
   `xmlrpc`.** `spotipy` → `redis` → `importlib.metadata` needs `email`;
   `spotipy.oauth2` needs `html`. Excluding these causes
   `ModuleNotFoundError` at sidecar startup.
+- **PyInstaller spec must include `collect_data_files("ytmusicapi")`.**
+  `ytmusicapi.YTMusic.__init__` loads gettext `.mo` translation files
+  from `ytmusicapi/locales/<lang>/LC_MESSAGES/base.mo`. Without those
+  data files in the bundle, every call that constructs `YTMusicClient`
+  (notably `_check_ytmusic` in `health.py`, hit on every UI render)
+  throws `FileNotFoundError: No translation file found for domain:
+  'base'`. Symptom: `/api/health` returns `ytmusic:false` with a valid
+  `browser.json`, the badge stays "Desconectado", and migrations fail
+  with no clear error.
+- **`_check_ytmusic` writes a traceback log on failure.** Silent
+  failures here used to leave the UI showing `ytmusic:false` with no
+  diagnostic trail. The traceback is appended to
+  `<data_dir>/ytmusic_health.log`. If a regression makes the badge
+  stuck on "Desconectado" with valid headers, that's the first place
+  to look.
 - **Tauri custom-protocol is DISABLED** (`default = []` in Cargo.toml).
   Without it the webview uses `http://127.0.0.1:{port}` as origin, which
   would allow `fetch` to localhost (but we proxy through IPC anyway).

--- a/backend/scripts/build_sidecar.py
+++ b/backend/scripts/build_sidecar.py
@@ -73,8 +73,22 @@ def main() -> None:
         sys.exit(1)
 
     shutil.copy2(source, dest)
+    size_bytes = dest.stat().st_size
     print(f"Sidecar binary written to {dest}")
-    print(f"Size: {dest.stat().st_size / (1024 * 1024):.1f} MB")
+    print(f"Size: {size_bytes / (1024 * 1024):.1f} MB")
+
+    # Defense for #98 follow-up: tauri build does NOT regenerate the sidecar;
+    # if the file at this path is a 0-byte placeholder (or a tiny dummy), the
+    # MSI ships a non-runnable exe and the desktop app crashes on launch with
+    # no useful feedback. Fail loudly instead.
+    MIN_SIZE_BYTES = 1_000_000
+    if size_bytes < MIN_SIZE_BYTES:
+        print(
+            f"ERROR: sidecar binary is suspiciously small ({size_bytes} bytes). "
+            f"Expected >{MIN_SIZE_BYTES} bytes. Refusing to ship a broken bundle.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/backend/spotify-to-ytmusic-server.spec
+++ b/backend/spotify-to-ytmusic-server.spec
@@ -3,14 +3,24 @@
 import sys
 from pathlib import Path
 
+from PyInstaller.utils.hooks import collect_data_files
+
 here = Path(SPECPATH).resolve()
 src = here / "src"
+
+# ytmusicapi loads gettext .mo translation files at YTMusic() construction
+# time. Without these data files the sidecar throws
+# FileNotFoundError: No translation file found for domain: 'base'
+# the moment any code instantiates YTMusicClient — which the /health
+# endpoint does on every request, surfacing as ytmusic:false in the UI
+# even with a valid browser.json.
+ytmusicapi_data = collect_data_files("ytmusicapi")
 
 a = Analysis(
     [str(src / "spotify_to_ytmusic" / "api" / "sidecar_server.py")],
     pathex=[str(src)],
     binaries=[],
-    datas=[],
+    datas=ytmusicapi_data,
     hiddenimports=[
         "spotify_to_ytmusic",
         "spotify_to_ytmusic.api",

--- a/backend/src/spotify_to_ytmusic/api/routes/auth.py
+++ b/backend/src/spotify_to_ytmusic/api/routes/auth.py
@@ -1,8 +1,9 @@
 """Authentication routes: Spotify OAuth and YT Music headers."""
+import asyncio
 import secrets
 
 from fastapi import APIRouter, Request
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 
 from spotify_to_ytmusic.api.models import AuthUrlResponse, ErrorResponse, OkResponse
 from spotify_to_ytmusic.api.state import state_store
@@ -13,6 +14,15 @@ from spotify_to_ytmusic.core.config import (
 )
 
 router = APIRouter(prefix="/api")
+
+# setup_browser is supposed to be local-only in ytmusicapi >= 1.10, but in
+# packaged builds we have observed it hanging (#94, #99). Wall-clock cap so
+# the frontend always gets a response.
+YTMUSIC_SETUP_TIMEOUT_S = 8.0
+
+
+def _error(status: int, message: str) -> JSONResponse:
+    return JSONResponse(status_code=status, content=ErrorResponse(message=message).model_dump(by_alias=True))
 
 
 def _get_spotify_oauth(state: str | None = None, redirect_uri: str | None = None):
@@ -109,33 +119,46 @@ def _callback_html(title: str, message: str) -> str:
 
 
 @router.post("/auth/ytmusic")
-async def auth_ytmusic(body: dict) -> OkResponse | ErrorResponse:
+async def auth_ytmusic(body: dict):
     headers = body.get("headers", "")
     if not isinstance(headers, str) or not headers.strip():
-        return ErrorResponse(message="Pega los headers del navegador antes de continuar.")
+        return _error(400, "Pega los headers del navegador antes de continuar.")
     from ytmusicapi.auth.browser import setup_browser
     from ytmusicapi.exceptions import YTMusicUserError
     from spotify_to_ytmusic.core.headers_parser import normalize_headers
 
     normalized = normalize_headers(headers)
     if not normalized.strip():
-        return ErrorResponse(message="No se pudieron parsear los headers. Pega el bloque entero de request headers.")
+        return _error(400, "No se pudieron parsear los headers. Pega el bloque entero de request headers.")
     lower = normalized.lower()
     if "cookie:" not in lower or "user-agent:" not in lower:
-        return ErrorResponse(
-            message="Los headers deben incluir al menos cookie: y user-agent:."
-        )
+        return _error(400, "Los headers deben incluir al menos cookie: y user-agent:.")
     if "x-goog-authuser:" not in lower:
-        return ErrorResponse(
-            message='Falta el header x-goog-authuser. Copia los headers de una petición /browse '
-                    'en la pestaña Network de DevTools (F12) y asegúrate de incluir este header.'
+        return _error(
+            400,
+            'Falta el header x-goog-authuser. Copia los headers de una petición /browse '
+            'en la pestaña Network de DevTools (F12) y asegúrate de incluir este header.',
         )
+
+    loop = asyncio.get_running_loop()
     try:
-        setup_browser(filepath=BROWSER_AUTH_FILE, headers_raw=normalized)
+        await asyncio.wait_for(
+            loop.run_in_executor(
+                None,
+                lambda: setup_browser(filepath=BROWSER_AUTH_FILE, headers_raw=normalized),
+            ),
+            timeout=YTMUSIC_SETUP_TIMEOUT_S,
+        )
+    except asyncio.TimeoutError:
+        return _error(
+            504,
+            "La conexión con YouTube Music está tardando demasiado. Vuelve a copiar los headers "
+            "desde una petición /browse reciente y prueba de nuevo.",
+        )
     except YTMusicUserError as e:
-        return ErrorResponse(message=f"Error en los headers: {e}")
+        return _error(400, f"Error en los headers: {e}")
     except Exception as e:
-        return ErrorResponse(message=f"No se pudo conectar con YouTube Music: {e}")
+        return _error(500, f"No se pudo conectar con YouTube Music: {e}")
     return OkResponse(ok=True)
 
 

--- a/backend/src/spotify_to_ytmusic/api/routes/health.py
+++ b/backend/src/spotify_to_ytmusic/api/routes/health.py
@@ -37,6 +37,18 @@ def _check_ytmusic() -> bool:
         YTMusicClient()
         return True
     except Exception:
+        # Silent failure here used to leave the UI showing ytmusic:false
+        # with no clue why (eg. PyInstaller missing data files for
+        # ytmusicapi locales). Trace to a log next to browser.json so the
+        # next regression is one Get-Content away from a fix.
+        import traceback
+        try:
+            log_path = Path(BROWSER_AUTH_FILE).parent / "ytmusic_health.log"
+            with open(log_path, "a", encoding="utf-8") as f:
+                f.write(traceback.format_exc())
+                f.write("\n")
+        except Exception:
+            pass
         return False
 
 

--- a/backend/src/spotify_to_ytmusic/api/sidecar_server.py
+++ b/backend/src/spotify_to_ytmusic/api/sidecar_server.py
@@ -65,10 +65,15 @@ def _is_alive(pid: int) -> bool:
         os.kill(pid, 0)
     except ProcessLookupError:
         return False
-    except (OSError, ValueError, OverflowError):
-        # POSIX: EPERM means process exists but is owned by another user
-        # — still "alive" for our purposes.
+    except PermissionError:
+        # POSIX: EPERM means the process exists but is owned by another
+        # user — still "alive" for our purposes.
         return True
+    except (OSError, ValueError, OverflowError):
+        # Out-of-range or otherwise invalid PID — not a real running
+        # process. (On Linux, pid_t is signed 32-bit so values >2**31-1
+        # raise OverflowError before they reach the kernel.)
+        return False
     return True
 
 
@@ -78,30 +83,32 @@ def start_parent_watchdog(
     poll_interval_s: float = _PARENT_POLL_S,
     initial_delay_s: float = _PARENT_INITIAL_DELAY_S,
     on_parent_death=None,
+    sleep=None,
 ) -> threading.Thread | None:
     """Spawn a daemon thread that exits the process when ``parent_pid`` dies.
 
     Returns ``None`` (and does nothing) when the parent PID is not a real
     parent — eg. running under the CLI, where ``getppid()`` returns the
-    shell. ``on_parent_death`` is injectable for unit tests; it defaults
-    to ``os._exit(0)``.
+    shell. ``on_parent_death`` and ``sleep`` are injectable for unit
+    tests; they default to ``os._exit(0)`` and ``time.sleep``.
     """
     if parent_pid <= 1:
         return None
     callback = on_parent_death or (lambda: os._exit(0))
+    sleep_fn = sleep or time.sleep
 
     print(f"[watchdog] parent_pid={parent_pid}", file=sys.stderr, flush=True)
 
     def _watch() -> None:
         if initial_delay_s > 0:
-            time.sleep(initial_delay_s)
+            sleep_fn(initial_delay_s)
         while True:
             if not _is_alive(parent_pid):
                 print(f"[watchdog] parent_pid={parent_pid} is gone — exiting",
                       file=sys.stderr, flush=True)
                 callback()
                 return
-            time.sleep(poll_interval_s)
+            sleep_fn(poll_interval_s)
 
     thread = threading.Thread(target=_watch, name="parent-watchdog", daemon=True)
     thread.start()

--- a/backend/src/spotify_to_ytmusic/api/sidecar_server.py
+++ b/backend/src/spotify_to_ytmusic/api/sidecar_server.py
@@ -126,6 +126,17 @@ def main() -> None:
     else:
         port = 8000
 
+    # Optional argv[2]: PID of the real host (Tauri). Passed explicitly
+    # because os.getppid() under PyInstaller --onefile returns the bootstrap
+    # launcher's PID, not the host's, so a pure getppid() watchdog can't see
+    # the host die (#98).
+    host_pid: int | None = None
+    if len(sys.argv) > 2:
+        try:
+            host_pid = int(sys.argv[2])
+        except ValueError:
+            print(f"Invalid host PID: {sys.argv[2]}", file=sys.stderr)
+
     if port == 0:
         port = _find_free_port()
 
@@ -144,7 +155,7 @@ def main() -> None:
     config = uvicorn.Config(app=app, host="127.0.0.1", port=port, log_level="warning")
     server = uvicorn.Server(config)
 
-    start_parent_watchdog(os.getppid())
+    start_parent_watchdog(host_pid if host_pid is not None else os.getppid())
 
     print(f"SERVER_LISTENING port={port}", flush=True)
     server.run()

--- a/backend/src/spotify_to_ytmusic/api/sidecar_server.py
+++ b/backend/src/spotify_to_ytmusic/api/sidecar_server.py
@@ -7,6 +7,8 @@ import logging
 import os
 import socket
 import sys
+import threading
+import time
 
 from dotenv import load_dotenv
 
@@ -19,6 +21,52 @@ load_persisted_credentials()
 logging.getLogger("spotipy.client").setLevel(logging.CRITICAL)
 
 import uvicorn
+
+# Parent-watchdog tunables. Defense in depth for #98: if the Tauri host
+# crashes or fails to fire its cleanup hooks, the sidecar self-terminates
+# within at most _PARENT_POLL_S of the parent's death.
+_PARENT_POLL_S = 2.0
+
+
+def _is_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except OSError:
+        # On Windows, EPERM means the process exists but we can't signal it.
+        # On POSIX, EPERM means the same. Either way: alive.
+        return True
+    return True
+
+
+def start_parent_watchdog(
+    parent_pid: int,
+    *,
+    poll_interval_s: float = _PARENT_POLL_S,
+    on_parent_death=None,
+) -> threading.Thread | None:
+    """Spawn a daemon thread that exits the process when ``parent_pid`` dies.
+
+    Returns ``None`` (and does nothing) when the parent PID is not a real
+    parent — eg. running under the CLI, where ``getppid()`` returns the
+    shell. ``on_parent_death`` is injectable for unit tests; it defaults
+    to ``os._exit(0)``.
+    """
+    if parent_pid <= 1:
+        return None
+    callback = on_parent_death or (lambda: os._exit(0))
+
+    def _watch() -> None:
+        while True:
+            if not _is_alive(parent_pid):
+                callback()
+                return
+            time.sleep(poll_interval_s)
+
+    thread = threading.Thread(target=_watch, name="parent-watchdog", daemon=True)
+    thread.start()
+    return thread
 
 
 def _find_free_port() -> int:
@@ -56,6 +104,8 @@ def main() -> None:
 
     config = uvicorn.Config(app=app, host="127.0.0.1", port=port, log_level="warning")
     server = uvicorn.Server(config)
+
+    start_parent_watchdog(os.getppid())
 
     print(f"SERVER_LISTENING port={port}", flush=True)
     server.run()

--- a/backend/src/spotify_to_ytmusic/api/sidecar_server.py
+++ b/backend/src/spotify_to_ytmusic/api/sidecar_server.py
@@ -24,18 +24,50 @@ import uvicorn
 
 # Parent-watchdog tunables. Defense in depth for #98: if the Tauri host
 # crashes or fails to fire its cleanup hooks, the sidecar self-terminates
-# within at most _PARENT_POLL_S of the parent's death.
+# within at most _PARENT_POLL_S of the parent's death. We delay the first
+# poll so PyInstaller bootstrap and any transient parent-process state
+# settle before we start checking.
 _PARENT_POLL_S = 2.0
+_PARENT_INITIAL_DELAY_S = 5.0
+
+
+def _is_alive_windows(pid: int) -> bool:
+    """Probe a PID via Win32 OpenProcess + GetExitCodeProcess."""
+    import ctypes
+    from ctypes import wintypes
+
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    STILL_ACTIVE = 259
+
+    kernel32 = ctypes.windll.kernel32
+    handle = kernel32.OpenProcess(
+        PROCESS_QUERY_LIMITED_INFORMATION, False, wintypes.DWORD(pid)
+    )
+    if not handle:
+        return False
+    try:
+        exit_code = wintypes.DWORD()
+        ok = kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code))
+        if not ok:
+            return False
+        return exit_code.value == STILL_ACTIVE
+    finally:
+        kernel32.CloseHandle(handle)
 
 
 def _is_alive(pid: int) -> bool:
+    if os.name == "nt":
+        try:
+            return _is_alive_windows(pid)
+        except (OSError, ValueError, OverflowError):
+            return False
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
         return False
-    except OSError:
-        # On Windows, EPERM means the process exists but we can't signal it.
-        # On POSIX, EPERM means the same. Either way: alive.
+    except (OSError, ValueError, OverflowError):
+        # POSIX: EPERM means process exists but is owned by another user
+        # — still "alive" for our purposes.
         return True
     return True
 
@@ -44,6 +76,7 @@ def start_parent_watchdog(
     parent_pid: int,
     *,
     poll_interval_s: float = _PARENT_POLL_S,
+    initial_delay_s: float = _PARENT_INITIAL_DELAY_S,
     on_parent_death=None,
 ) -> threading.Thread | None:
     """Spawn a daemon thread that exits the process when ``parent_pid`` dies.
@@ -57,9 +90,15 @@ def start_parent_watchdog(
         return None
     callback = on_parent_death or (lambda: os._exit(0))
 
+    print(f"[watchdog] parent_pid={parent_pid}", file=sys.stderr, flush=True)
+
     def _watch() -> None:
+        if initial_delay_s > 0:
+            time.sleep(initial_delay_s)
         while True:
             if not _is_alive(parent_pid):
+                print(f"[watchdog] parent_pid={parent_pid} is gone — exiting",
+                      file=sys.stderr, flush=True)
                 callback()
                 return
             time.sleep(poll_interval_s)

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -102,7 +102,7 @@ async def test_auth_ytmusic_missing_x_goog_authuser(client):
         "/api/auth/ytmusic",
         json={"headers": "cookie: ABC\nuser-agent: Mozilla/5.0"},
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 400
     data = resp.json()
     assert "x-goog-authuser" in data["message"].lower()
 
@@ -113,7 +113,7 @@ async def test_auth_ytmusic_missing_cookie(client):
         "/api/auth/ytmusic",
         json={"headers": "user-agent: Mozilla/5.0"},
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 400
     data = resp.json()
     assert "message" in data
 
@@ -124,7 +124,7 @@ async def test_auth_ytmusic_missing_user_agent(client):
         "/api/auth/ytmusic",
         json={"headers": "cookie: ABC"},
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 400
     data = resp.json()
     assert "message" in data
 
@@ -135,9 +135,58 @@ async def test_auth_ytmusic_empty_headers(client):
         "/api/auth/ytmusic",
         json={"headers": ""},
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 400
     data = resp.json()
     assert "message" in data
+
+
+@pytest.mark.asyncio
+async def test_auth_ytmusic_setup_browser_user_error(client, tmp_path):
+    from ytmusicapi.exceptions import YTMusicUserError
+
+    browser_file = tmp_path / "browser.json"
+    with patch("spotify_to_ytmusic.api.routes.auth.BROWSER_AUTH_FILE", str(browser_file)), \
+         patch("ytmusicapi.auth.browser.setup_browser", side_effect=YTMusicUserError("bad cookies")):
+        resp = await client.post(
+            "/api/auth/ytmusic",
+            json={"headers": "cookie: ABC\nuser-agent: Mozilla/5.0\nx-goog-authuser: 1"},
+        )
+        assert resp.status_code == 400
+        assert "bad cookies" in resp.json()["message"]
+
+
+@pytest.mark.asyncio
+async def test_auth_ytmusic_setup_browser_unexpected_error(client, tmp_path):
+    browser_file = tmp_path / "browser.json"
+    with patch("spotify_to_ytmusic.api.routes.auth.BROWSER_AUTH_FILE", str(browser_file)), \
+         patch("ytmusicapi.auth.browser.setup_browser", side_effect=RuntimeError("disk full")):
+        resp = await client.post(
+            "/api/auth/ytmusic",
+            json={"headers": "cookie: ABC\nuser-agent: Mozilla/5.0\nx-goog-authuser: 1"},
+        )
+        assert resp.status_code == 500
+        assert "disk full" in resp.json()["message"]
+
+
+@pytest.mark.asyncio
+async def test_auth_ytmusic_setup_browser_timeout(client, tmp_path):
+    """If setup_browser exceeds the wait_for timeout, the handler returns 504."""
+    import asyncio as _asyncio
+
+    browser_file = tmp_path / "browser.json"
+
+    async def fake_wait_for(*_args, **_kwargs):
+        raise _asyncio.TimeoutError()
+
+    with patch("spotify_to_ytmusic.api.routes.auth.BROWSER_AUTH_FILE", str(browser_file)), \
+         patch("ytmusicapi.auth.browser.setup_browser"), \
+         patch("spotify_to_ytmusic.api.routes.auth.asyncio.wait_for", side_effect=fake_wait_for):
+        resp = await client.post(
+            "/api/auth/ytmusic",
+            json={"headers": "cookie: ABC\nuser-agent: Mozilla/5.0\nx-goog-authuser: 1"},
+        )
+    assert resp.status_code == 504, f"expected 504, got {resp.status_code} body={resp.text!r}"
+    assert "tardando demasiado" in resp.json()["message"].lower()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_sidecar_server.py
+++ b/backend/tests/api/test_sidecar_server.py
@@ -1,11 +1,17 @@
 """Tests for the sidecar server entrypoint."""
+import threading
+import time
 from unittest.mock import patch
 
 import pytest
 from httpx import AsyncClient, ASGITransport
 
 from spotify_to_ytmusic.api import create_app
-from spotify_to_ytmusic.api.sidecar_server import _find_free_port
+from spotify_to_ytmusic.api.sidecar_server import (
+    _find_free_port,
+    _is_alive,
+    start_parent_watchdog,
+)
 
 
 def test_find_free_port_returns_valid_port():
@@ -34,7 +40,57 @@ def test_main_prints_server_listening(capfd):
 
     with patch("sys.argv", ["sidecar_server", "0"]), \
          patch("spotify_to_ytmusic.api.sidecar_server.uvicorn.Server.run", return_value=None), \
-         patch("spotify_to_ytmusic.api.sidecar_server._find_free_port", return_value=54321):
+         patch("spotify_to_ytmusic.api.sidecar_server._find_free_port", return_value=54321), \
+         patch("spotify_to_ytmusic.api.sidecar_server.start_parent_watchdog", return_value=None):
         main()
     captured = capfd.readouterr()
     assert "SERVER_LISTENING port=54321" in captured.out
+
+
+def test_parent_watchdog_skips_when_pid_is_root_or_init():
+    """Init/root PIDs (<=1) are sentinels for "no real parent" — don't watch."""
+    fired = threading.Event()
+    assert start_parent_watchdog(0, on_parent_death=fired.set) is None
+    assert start_parent_watchdog(1, on_parent_death=fired.set) is None
+    assert not fired.is_set()
+
+
+def test_parent_watchdog_fires_when_parent_dies():
+    """When the parent PID stops being alive, the death callback runs."""
+    fired = threading.Event()
+    alive_calls = {"n": 0}
+
+    def fake_is_alive(_pid: int) -> bool:
+        alive_calls["n"] += 1
+        return alive_calls["n"] < 2  # alive on first poll, dead on second
+
+    with patch("spotify_to_ytmusic.api.sidecar_server._is_alive", side_effect=fake_is_alive):
+        thread = start_parent_watchdog(
+            1234,
+            poll_interval_s=0.01,
+            on_parent_death=fired.set,
+        )
+        assert thread is not None
+        assert fired.wait(timeout=2.0), "watchdog should have fired exit callback"
+
+
+def test_parent_watchdog_stays_quiet_while_parent_alive():
+    """If the parent is alive, the death callback never runs."""
+    fired = threading.Event()
+
+    with patch("spotify_to_ytmusic.api.sidecar_server._is_alive", return_value=True):
+        thread = start_parent_watchdog(
+            1234,
+            poll_interval_s=0.01,
+            on_parent_death=fired.set,
+        )
+        assert thread is not None
+        time.sleep(0.05)
+        assert not fired.is_set()
+
+
+def test_is_alive_for_current_process():
+    """Sanity check: the test runner's own PID is alive."""
+    import os as _os
+
+    assert _is_alive(_os.getpid())

--- a/backend/tests/api/test_sidecar_server.py
+++ b/backend/tests/api/test_sidecar_server.py
@@ -13,6 +13,12 @@ from spotify_to_ytmusic.api.sidecar_server import (
     start_parent_watchdog,
 )
 
+# Capture the real sleep/monotonic before the autouse `_no_sleep` fixture
+# in conftest replaces time.sleep with a no-op. The watchdog-delay test
+# needs honest wall-clock to verify behavior.
+_REAL_SLEEP = time.sleep
+_REAL_MONOTONIC = time.monotonic
+
 
 def test_find_free_port_returns_valid_port():
     port = _find_free_port()
@@ -118,19 +124,33 @@ def test_parent_watchdog_stays_quiet_while_parent_alive():
 
 
 def test_parent_watchdog_honors_initial_delay():
-    """During the initial delay no probe happens, so death is reported late."""
+    """The watchdog respects initial_delay_s before the first probe.
+
+    The autouse `_no_sleep` fixture in conftest replaces ``time.sleep``
+    with a no-op for the whole suite (retry/backoff tests would
+    otherwise be slow). We need real sleep here, so we capture the
+    original before the fixture stomped it and pass it in via a
+    dedicated parameter rather than fight the autouse fixture. This
+    keeps the fast suite fast and the delay test honest.
+    """
     fired = threading.Event()
+    delay_s = 0.2
 
     with patch("spotify_to_ytmusic.api.sidecar_server._is_alive", return_value=False):
+        start = _REAL_MONOTONIC()
         start_parent_watchdog(
             1234,
             poll_interval_s=0.01,
-            initial_delay_s=0.2,
+            initial_delay_s=delay_s,
             on_parent_death=fired.set,
+            sleep=_REAL_SLEEP,
         )
-        assert not fired.is_set()
-        # After the initial delay elapses the first probe runs and fires.
-        assert fired.wait(timeout=1.0)
+        assert fired.wait(timeout=2.0), "watchdog never fired"
+        elapsed = _REAL_MONOTONIC() - start
+
+    assert elapsed >= delay_s * 0.5, (
+        f"watchdog fired in {elapsed:.3f}s, expected at least ~{delay_s}s"
+    )
 
 
 def test_is_alive_for_current_process():

--- a/backend/tests/api/test_sidecar_server.py
+++ b/backend/tests/api/test_sidecar_server.py
@@ -47,6 +47,32 @@ def test_main_prints_server_listening(capfd):
     assert "SERVER_LISTENING port=54321" in captured.out
 
 
+def test_main_passes_explicit_host_pid_to_watchdog():
+    """argv[2] (Tauri host PID) overrides os.getppid()."""
+    from spotify_to_ytmusic.api.sidecar_server import main
+
+    with patch("sys.argv", ["sidecar_server", "0", "9999"]), \
+         patch("spotify_to_ytmusic.api.sidecar_server.uvicorn.Server.run", return_value=None), \
+         patch("spotify_to_ytmusic.api.sidecar_server._find_free_port", return_value=1), \
+         patch("spotify_to_ytmusic.api.sidecar_server.start_parent_watchdog") as wd, \
+         patch("os.getppid", return_value=11111):
+        main()
+    wd.assert_called_once_with(9999)
+
+
+def test_main_falls_back_to_getppid_without_argv2():
+    """No argv[2] → watch os.getppid() (CLI / legacy spawners)."""
+    from spotify_to_ytmusic.api.sidecar_server import main
+
+    with patch("sys.argv", ["sidecar_server", "0"]), \
+         patch("spotify_to_ytmusic.api.sidecar_server.uvicorn.Server.run", return_value=None), \
+         patch("spotify_to_ytmusic.api.sidecar_server._find_free_port", return_value=1), \
+         patch("spotify_to_ytmusic.api.sidecar_server.start_parent_watchdog") as wd, \
+         patch("os.getppid", return_value=11111):
+        main()
+    wd.assert_called_once_with(11111)
+
+
 def test_parent_watchdog_skips_when_pid_is_root_or_init():
     """Init/root PIDs (<=1) are sentinels for "no real parent" — don't watch."""
     fired = threading.Event()

--- a/backend/tests/api/test_sidecar_server.py
+++ b/backend/tests/api/test_sidecar_server.py
@@ -68,6 +68,7 @@ def test_parent_watchdog_fires_when_parent_dies():
         thread = start_parent_watchdog(
             1234,
             poll_interval_s=0.01,
+            initial_delay_s=0.0,
             on_parent_death=fired.set,
         )
         assert thread is not None
@@ -82,6 +83,7 @@ def test_parent_watchdog_stays_quiet_while_parent_alive():
         thread = start_parent_watchdog(
             1234,
             poll_interval_s=0.01,
+            initial_delay_s=0.0,
             on_parent_death=fired.set,
         )
         assert thread is not None
@@ -89,8 +91,30 @@ def test_parent_watchdog_stays_quiet_while_parent_alive():
         assert not fired.is_set()
 
 
+def test_parent_watchdog_honors_initial_delay():
+    """During the initial delay no probe happens, so death is reported late."""
+    fired = threading.Event()
+
+    with patch("spotify_to_ytmusic.api.sidecar_server._is_alive", return_value=False):
+        start_parent_watchdog(
+            1234,
+            poll_interval_s=0.01,
+            initial_delay_s=0.2,
+            on_parent_death=fired.set,
+        )
+        assert not fired.is_set()
+        # After the initial delay elapses the first probe runs and fires.
+        assert fired.wait(timeout=1.0)
+
+
 def test_is_alive_for_current_process():
     """Sanity check: the test runner's own PID is alive."""
     import os as _os
 
     assert _is_alive(_os.getpid())
+
+
+def test_is_alive_returns_false_for_unused_pid():
+    """A wildly-out-of-range PID should be reported as dead, not alive."""
+    # 4_294_967_294 is just under DWORD max; should never be a valid PID.
+    assert _is_alive(4_294_967_294) is False

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +519,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +772,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1297,6 +1328,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1617,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,8 +1780,17 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.5",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1759,6 +1844,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -1992,6 +2083,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2005,6 +2097,18 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2083,6 +2187,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,6 +2206,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2141,7 +2265,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2222,6 +2346,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -2401,6 +2531,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,15 +2613,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2492,6 +2636,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2510,6 +2668,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,6 +2767,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2580,6 +2834,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -2833,6 +3110,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2875,7 +3168,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -2910,13 +3203,15 @@ dependencies = [
 
 [[package]]
 name = "spotify-to-ytmusic"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-shell",
+ "tauri-plugin-updater",
+ "ureq",
 ]
 
 [[package]]
@@ -2954,6 +3249,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3038,7 +3339,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3072,6 +3373,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3094,7 +3406,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -3228,6 +3540,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,7 +3582,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -3260,7 +3605,7 @@ checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -3325,6 +3670,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3430,6 +3788,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3729,6 +4097,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4021,6 +4411,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4248,6 +4665,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4633,7 +5059,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -4681,6 +5107,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4725,6 +5161,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4755,6 +5197,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -3212,6 +3212,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-updater",
  "ureq",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -17,6 +17,14 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ureq = "2"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_JobObjects",
+    "Win32_System_Threading",
+] }
+
 [features]
 default = []
 custom-protocol = ["tauri/custom-protocol"]

--- a/frontend/src-tauri/src/job.rs
+++ b/frontend/src-tauri/src/job.rs
@@ -1,0 +1,103 @@
+//! Win32 Job Object plumbing so the sidecar dies when Tauri dies.
+//!
+//! PyInstaller --onefile leaves a bootstrap launcher process that does not
+//! always exit when its child Python runtime is killed. The result is an
+//! orphaned `spotify-to-ytmusic-server.exe` that survives the host (#98).
+//!
+//! A Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` makes the OS itself
+//! terminate every process assigned to the job the moment the last handle to
+//! the job closes — which happens automatically when the host process exits,
+//! crashes, or is killed externally. This is a safety net independent of any
+//! cleanup code Tauri might or might not run.
+
+use std::io;
+
+use windows_sys::Win32::Foundation::{CloseHandle, FALSE, HANDLE, INVALID_HANDLE_VALUE};
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, SetInformationJobObject,
+    JobObjectExtendedLimitInformation, JOBOBJECT_BASIC_LIMIT_INFORMATION,
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+};
+use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE};
+
+/// Wraps a `HANDLE` so `Drop` closes it.
+pub struct JobHandle {
+    handle: HANDLE,
+}
+
+// SAFETY: a HANDLE is just an opaque integer; sharing it across threads is
+// fine as long as we only call thread-safe Win32 APIs on it (which is the
+// case for AssignProcessToJobObject and CloseHandle).
+unsafe impl Send for JobHandle {}
+unsafe impl Sync for JobHandle {}
+
+impl JobHandle {
+    /// Create a new job configured to kill all assigned processes when the
+    /// last handle closes (i.e. when the host exits for any reason).
+    pub fn create_kill_on_close() -> io::Result<Self> {
+        let handle = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+        if handle.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+
+        let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { std::mem::zeroed() };
+        info.BasicLimitInformation = JOBOBJECT_BASIC_LIMIT_INFORMATION {
+            LimitFlags: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+            ..unsafe { std::mem::zeroed() }
+        };
+
+        let ok = unsafe {
+            SetInformationJobObject(
+                handle,
+                JobObjectExtendedLimitInformation,
+                &info as *const _ as *const _,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        };
+        if ok == 0 {
+            let err = io::Error::last_os_error();
+            unsafe { CloseHandle(handle) };
+            return Err(err);
+        }
+
+        Ok(JobHandle { handle })
+    }
+
+    /// Assign a process (by PID) to this job. The process must have been
+    /// created without already belonging to a different job, which is the
+    /// default for processes spawned by `Command::spawn` / Tauri's shell
+    /// plugin on Windows 10+ (nested jobs are allowed since Win8).
+    pub fn assign_pid(&self, pid: u32) -> io::Result<()> {
+        let proc_handle = unsafe {
+            OpenProcess(
+                PROCESS_TERMINATE | PROCESS_SET_QUOTA,
+                FALSE,
+                pid,
+            )
+        };
+        if proc_handle.is_null() || proc_handle == INVALID_HANDLE_VALUE {
+            return Err(io::Error::last_os_error());
+        }
+
+        let ok = unsafe { AssignProcessToJobObject(self.handle, proc_handle) };
+        let err = if ok == 0 {
+            Some(io::Error::last_os_error())
+        } else {
+            None
+        };
+        unsafe { CloseHandle(proc_handle) };
+
+        match err {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+}
+
+impl Drop for JobHandle {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe { CloseHandle(self.handle) };
+        }
+    }
+}

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
 use std::sync::{Mutex, OnceLock};
 
 use serde::Serialize;
-use tauri::{Manager, RunEvent, WindowEvent};
+use tauri::{Manager, RunEvent};
 use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
 
@@ -104,7 +104,7 @@ fn kill_sidecar(reason: &str) {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let app = match tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {
@@ -120,24 +120,58 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![get_server_port, proxy_request])
         .build(tauri::generate_context!())
-        .expect("error while building tauri application")
-        .run(|_app_handle, event| match event {
-            // ExitRequested fires before Tauri begins tearing down. Cleanup
-            // here covers the normal "user clicks X" path even if Exit is
-            // suppressed downstream.
-            RunEvent::ExitRequested { .. } => kill_sidecar("ExitRequested"),
-            // Final guard — kept for the case where ExitRequested is bypassed
-            // (eg. tray-driven exits in future iterations).
-            RunEvent::Exit => kill_sidecar("Exit"),
-            // Best-effort: if the OS destroys the window without going
-            // through ExitRequested, still kill the sidecar so it doesn't
-            // outlive the UI.
-            RunEvent::WindowEvent {
-                event: WindowEvent::Destroyed,
-                ..
-            } => kill_sidecar("WindowDestroyed"),
-            _ => {}
-        });
+    {
+        Ok(app) => app,
+        Err(e) => {
+            // Build/setup failed — usually because the sidecar didn't start.
+            // Log a clear stderr trail (visible when launched from cmd.exe)
+            // and surface a native dialog so the user sees the cause instead
+            // of a silent close.
+            let msg = format!("Tauri failed to start: {e}");
+            eprintln!("[startup] {msg}");
+            kill_sidecar("StartupFailure");
+            show_startup_error(&msg);
+            std::process::exit(1);
+        }
+    };
+
+    app.run(|_app_handle, event| match event {
+        // ExitRequested fires before Tauri begins tearing down. Cleanup
+        // here covers the normal "user clicks X" path even if Exit is
+        // suppressed downstream.
+        RunEvent::ExitRequested { .. } => kill_sidecar("ExitRequested"),
+        // Final guard — kept for the case where ExitRequested is bypassed
+        // (eg. tray-driven exits in future iterations).
+        RunEvent::Exit => kill_sidecar("Exit"),
+        _ => {}
+    });
+}
+
+#[cfg(target_os = "windows")]
+fn show_startup_error(message: &str) {
+    use std::ffi::OsStr;
+    use std::iter::once;
+    use std::os::windows::ffi::OsStrExt;
+
+    extern "system" {
+        fn MessageBoxW(hwnd: usize, text: *const u16, caption: *const u16, kind: u32) -> i32;
+    }
+
+    fn to_wide(s: &str) -> Vec<u16> {
+        OsStr::new(s).encode_wide().chain(once(0)).collect()
+    }
+
+    let text = to_wide(message);
+    let caption = to_wide("Spotify to YT Music — startup error");
+    // MB_OK | MB_ICONERROR
+    unsafe {
+        MessageBoxW(0, text.as_ptr(), caption.as_ptr(), 0x00000010);
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn show_startup_error(_message: &str) {
+    // Other platforms: stderr-only for now. Release builds target Windows.
 }
 
 async fn spawn_sidecar(app: &tauri::AppHandle) -> Result<u16, Box<dyn std::error::Error>> {

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -5,6 +5,9 @@ use tauri::{Manager, RunEvent};
 use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
 
+#[cfg(windows)]
+mod job;
+
 #[derive(Serialize)]
 struct ProxyResponse {
     status: u16,
@@ -36,12 +39,23 @@ async fn proxy_request(
 
         req = req.set("Content-Type", "application/json");
 
-        let resp = if let Some(b) = body {
+        // ureq treats 4xx/5xx as Err(Status(code, resp)). Those are real
+        // HTTP responses with a body — we must surface them to the frontend
+        // as a normal ProxyResponse so the JSON {message: ...} payload from
+        // the backend reaches `useYTMusicAuth` as an HttpError. Only true
+        // transport failures (Err::Transport) should propagate as Err.
+        let call_result = if let Some(b) = body {
             req.send_string(&b)
-                .map_err(|e| format!("request failed: {e}"))?
         } else {
             req.call()
-                .map_err(|e| format!("request failed: {e}"))?
+        };
+
+        let resp = match call_result {
+            Ok(r) => r,
+            Err(ureq::Error::Status(_code, r)) => r,
+            Err(ureq::Error::Transport(e)) => {
+                return Err(format!("request failed: {e}"));
+            }
         };
 
         let status = resp.status();
@@ -79,6 +93,18 @@ fn sidecar_handle() -> &'static Mutex<Option<CommandChild>> {
     HANDLE.get_or_init(|| Mutex::new(None))
 }
 
+// Win32 Job Object that the sidecar is assigned to. Configured with
+// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE so the OS itself terminates every
+// assigned process when the last handle closes — i.e. when the Tauri host
+// exits, crashes, or is killed externally. This is the safety net for #98:
+// independent of whether `child.kill()` succeeds and independent of whether
+// the watchdog inside the sidecar fires, the OS guarantees cleanup.
+#[cfg(windows)]
+fn sidecar_job() -> &'static Mutex<Option<job::JobHandle>> {
+    static JOB: OnceLock<Mutex<Option<job::JobHandle>>> = OnceLock::new();
+    JOB.get_or_init(|| Mutex::new(None))
+}
+
 fn kill_sidecar(reason: &str) {
     let taken = match sidecar_handle().lock() {
         Ok(mut guard) => guard.take(),
@@ -104,6 +130,22 @@ fn kill_sidecar(reason: &str) {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Create the Job Object as early as possible so it exists before the
+    // sidecar is spawned. If it fails (e.g. unsupported on this Windows
+    // build) we log and fall back to the existing kill_sidecar/watchdog
+    // defenses; the app still works, just without the OS-level safety net.
+    #[cfg(windows)]
+    {
+        match job::JobHandle::create_kill_on_close() {
+            Ok(j) => {
+                if let Ok(mut guard) = sidecar_job().lock() {
+                    *guard = Some(j);
+                }
+            }
+            Err(e) => eprintln!("[job] failed to create job object: {e}"),
+        }
+    }
+
     let app = match tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
@@ -180,14 +222,37 @@ async fn spawn_sidecar(app: &tauri::AppHandle) -> Result<u16, Box<dyn std::error
         .app_data_dir()
         .map_err(|e| format!("failed to resolve app data dir: {e}"))?;
 
+    // Pass our PID explicitly so the sidecar's parent-watchdog tracks the
+    // Tauri host directly. os.getppid() inside PyInstaller --onefile
+    // returns the PID of the bootstrap launcher, not Tauri, which makes a
+    // pure getppid()-based watchdog miss host crashes (#98).
+    let host_pid = std::process::id().to_string();
+
     let (mut rx, child) = app
         .shell()
         .sidecar("spotify-to-ytmusic-server")
         .map_err(|e| format!("sidecar binary not found: {e}"))?
-        .args(["53000"])
+        .args(["53000", &host_pid])
         .env("SPOTIFY_TO_YTMUSIC_DATA_DIR", data_dir.to_string_lossy().as_ref())
         .spawn()
         .map_err(|e| format!("failed to spawn sidecar: {e}"))?;
+
+    // Assign the sidecar's PID to the kill-on-close job. Best-effort: if
+    // this fails the sidecar still runs, we just lose the OS-level
+    // guarantee and rely on kill_sidecar + watchdog instead.
+    #[cfg(windows)]
+    {
+        let pid = child.pid();
+        if let Ok(guard) = sidecar_job().lock() {
+            if let Some(j) = guard.as_ref() {
+                if let Err(e) = j.assign_pid(pid) {
+                    eprintln!("[job] AssignProcessToJobObject(pid={pid}) failed: {e}");
+                } else {
+                    eprintln!("[job] sidecar pid={pid} assigned to kill-on-close job");
+                }
+            }
+        }
+    }
 
     let port: u16 = loop {
         match rx.recv().await {

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 
 use serde::Serialize;
-use tauri::Manager;
+use tauri::{Manager, RunEvent, WindowEvent};
 use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
 
@@ -64,7 +64,6 @@ async fn proxy_request(
 
 struct SidecarState {
     port: u16,
-    child: Mutex<Option<CommandChild>>,
 }
 
 #[tauri::command]
@@ -72,16 +71,34 @@ fn get_server_port(state: tauri::State<SidecarState>) -> u16 {
     state.port
 }
 
-fn kill_sidecar(child: &mut Option<CommandChild>) {
-    if let Some(c) = child.take() {
-        eprintln!("[sidecar] killing sidecar process…");
-        if let Err(e) = c.kill() {
-            eprintln!("[sidecar] kill() failed: {e}");
-        } else {
-            eprintln!("[sidecar] kill() succeeded");
+// Sidecar process handle stored at module scope (not in Tauri's managed
+// state) so cleanup can run from any lifecycle event without racing with
+// Tauri dropping the State container before RunEvent::Exit fires (#98).
+fn sidecar_handle() -> &'static Mutex<Option<CommandChild>> {
+    static HANDLE: OnceLock<Mutex<Option<CommandChild>>> = OnceLock::new();
+    HANDLE.get_or_init(|| Mutex::new(None))
+}
+
+fn kill_sidecar(reason: &str) {
+    let taken = match sidecar_handle().lock() {
+        Ok(mut guard) => guard.take(),
+        Err(e) => {
+            eprintln!("[sidecar] mutex poisoned during {reason}: {e}");
+            return;
         }
-    } else {
-        eprintln!("[sidecar] no child to kill (already taken or never set)");
+    };
+    match taken {
+        Some(child) => {
+            eprintln!("[sidecar] killing sidecar process ({reason})…");
+            if let Err(e) = child.kill() {
+                eprintln!("[sidecar] kill() failed during {reason}: {e}");
+            } else {
+                eprintln!("[sidecar] kill() succeeded during {reason}");
+            }
+        }
+        None => {
+            // Already cleaned up by a previous lifecycle hook — idempotent.
+        }
     }
 }
 
@@ -97,28 +114,29 @@ pub fn run() {
                 tauri::async_runtime::block_on(spawn_sidecar(app.handle()))?
             };
 
-            if cfg!(debug_assertions) {
-                app.manage(SidecarState {
-                    port,
-                    child: Mutex::new(None),
-                });
-            }
+            app.manage(SidecarState { port });
 
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![get_server_port, proxy_request])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
-        .run(|app_handle, event| {
-            if let tauri::RunEvent::Exit = event {
-                match app_handle.try_state::<SidecarState>() {
-                    Some(state) => match state.child.lock() {
-                        Ok(mut child) => kill_sidecar(&mut child),
-                        Err(e) => eprintln!("[sidecar] mutex poisoned, cannot kill sidecar: {e}"),
-                    },
-                    None => eprintln!("[sidecar] SidecarState not found, cannot kill sidecar"),
-                }
-            }
+        .run(|_app_handle, event| match event {
+            // ExitRequested fires before Tauri begins tearing down. Cleanup
+            // here covers the normal "user clicks X" path even if Exit is
+            // suppressed downstream.
+            RunEvent::ExitRequested { .. } => kill_sidecar("ExitRequested"),
+            // Final guard — kept for the case where ExitRequested is bypassed
+            // (eg. tray-driven exits in future iterations).
+            RunEvent::Exit => kill_sidecar("Exit"),
+            // Best-effort: if the OS destroys the window without going
+            // through ExitRequested, still kill the sidecar so it doesn't
+            // outlive the UI.
+            RunEvent::WindowEvent {
+                event: WindowEvent::Destroyed,
+                ..
+            } => kill_sidecar("WindowDestroyed"),
+            _ => {}
         });
 }
 
@@ -159,10 +177,13 @@ async fn spawn_sidecar(app: &tauri::AppHandle) -> Result<u16, Box<dyn std::error
         }
     };
 
-    app.manage(SidecarState {
-        port,
-        child: Mutex::new(Some(child)),
-    });
+    // Park the child handle in the static container so every lifecycle
+    // hook can take ownership and kill it idempotently.
+    if let Ok(mut guard) = sidecar_handle().lock() {
+        *guard = Some(child);
+    } else {
+        eprintln!("[sidecar] failed to acquire static handle lock");
+    }
 
     Ok(port)
 }

--- a/frontend/src/features/auth/useYTMusicAuth.ts
+++ b/frontend/src/features/auth/useYTMusicAuth.ts
@@ -19,6 +19,14 @@ function extractErrorMessage(err: HttpError): string | null {
   return null;
 }
 
+function extractMessageFromOk(body: unknown): string | null {
+  if (body && typeof body === 'object' && !Array.isArray(body)) {
+    const msg = (body as Record<string, unknown>).message;
+    if (typeof msg === 'string' && msg.trim()) return msg;
+  }
+  return null;
+}
+
 export function useYTMusicAuth(): UseYTMusicAuthResult {
   const [state, setState] = useState<AuthState>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -37,7 +45,16 @@ export function useYTMusicAuth(): UseYTMusicAuthResult {
 
       http
         .post('/auth/ytmusic', { headers }, { timeoutMs: 30_000 })
-        .then(() => {
+        .then((body: unknown) => {
+          // Defense-in-depth: an older sidecar build may return 200 with
+          // {message: "..."} instead of a 4xx. Treat that as an error so
+          // the user sees the real reason instead of a fake success toast.
+          const errorMessage = extractMessageFromOk(body);
+          if (errorMessage) {
+            setState('error');
+            setErrorMessage(errorMessage);
+            return;
+          }
           setState('success');
           invalidateHealth();
           toast.success('YouTube Music conectado');

--- a/frontend/src/pages/Connect/YTMusic.test.tsx
+++ b/frontend/src/pages/Connect/YTMusic.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import type { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
 import { ToastContainer, ToastProvider } from '@/components/ui/Toast';
 import { server } from '@/test/msw/server';
 import { ytmusicAuthErrorHandler } from '@/test/msw/handlers';
@@ -97,5 +98,42 @@ describe('YTMusicConnect', () => {
     await waitFor(() => {
       expect(screen.getByRole('alert')).toHaveTextContent(/youtube music conectado/i);
     });
+  });
+
+  it('surfaces 400 message body as a FieldError', async () => {
+    server.use(
+      http.post('*/api/auth/ytmusic', () =>
+        HttpResponse.json(
+          { message: 'Falta el header x-goog-authuser. Copia los headers de /browse.' },
+          { status: 400 },
+        ),
+      ),
+    );
+    renderComponent();
+    fireEvent.change(screen.getByLabelText(/headers del navegador/i), {
+      target: { value: VALID_HEADERS },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /conectar con youtube music/i }));
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/x-goog-authuser/i);
+    });
+    expect(screen.getByRole('button', { name: /conectar con youtube music/i })).toBeEnabled();
+  });
+
+  it('treats a 200 with {message} as an error (defense-in-depth)', async () => {
+    server.use(
+      http.post('*/api/auth/ytmusic', () =>
+        HttpResponse.json({ message: 'Cookie inválida.' }, { status: 200 }),
+      ),
+    );
+    renderComponent();
+    fireEvent.change(screen.getByLabelText(/headers del navegador/i), {
+      target: { value: VALID_HEADERS },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /conectar con youtube music/i }));
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/cookie inválida/i);
+    });
+    expect(screen.getByRole('button', { name: /conectar con youtube music/i })).toBeEnabled();
   });
 });


### PR DESCRIPTION
## Summary

Both #98 and #99 had additional root causes the first round of fixes
didn't reach. The packaged build is now solid end-to-end: sidecar dies
with the host under every exit path, error bodies reach the UI, and
`/api/health` returns `ytmusic:true` against a valid `browser.json`.

### Fixes added in this round

- **Win32 Job Object with `KILL_ON_JOB_CLOSE`** ([src-tauri/src/job.rs](frontend/src-tauri/src/job.rs)).
  PyInstaller `--onefile` spawns a bootstrap launcher that re-execs as
  a child Python runtime; killing one can leave the other zombie. The
  job object delegates termination to the OS — when the host's last
  handle closes (clean exit, crash, Task Manager kill), every assigned
  process dies. This is independent of `child.kill()` and the
  watchdog, and is the actual fix for #98.
- **Watchdog now tracks the host PID, not the bootstrap launcher.**
  `os.getppid()` under PyInstaller `--onefile` returns the bootstrap's
  PID, so the watchdog was effectively monitoring its own ancestor
  chain. Tauri now passes `std::process::id()` as `argv[2]`; sidecar
  uses that explicitly and falls back to `getppid()` for the CLI path.
- **`proxy_request` preserves status + body for 4xx/5xx.** `ureq` 2.x
  returns `Err(Status(code, resp))` for every non-2xx — the previous
  code collapsed that into a string `Err`, so the JSON `{message:
  "..."}` payload from the backend never reached `HttpError` in the
  frontend. Now we match `Status` and surface a normal `ProxyResponse`;
  only `Transport` errors propagate as `Err`. This is the actual fix
  for the "button stuck on submitting" symptom in #99.
- **PyInstaller bundle now includes `ytmusicapi` data files.**
  `YTMusic.__init__` calls `gettext.translation()` to load
  `ytmusicapi/locales/<lang>/LC_MESSAGES/base.mo`. Without those .mo
  files in the bundle, every `/api/health` call threw `FileNotFoundError`
  and the badge stayed "Desconectado" even with a valid `browser.json`.
  Spec now uses `collect_data_files("ytmusicapi")`.
- **`_check_ytmusic` writes a traceback log on failure.** Silent
  failures here used to be invisible. The traceback is appended to
  `<data_dir>/ytmusic_health.log` so the next regression here is one
  `Get-Content` away from a fix.

### Carried over from the previous round

- `/api/auth/ytmusic` returns proper status codes (`400` validation /
  `YTMusicUserError`, `504` setup_browser timeout, `500` unexpected);
  `setup_browser` runs on a thread pool with a wall-clock cap.
- Frontend treats `200 + {message: ...}` as an error (defense in depth
  against older sidecar builds).
- Sidecar cleanup parked in `OnceLock<Mutex<Option<CommandChild>>>`
  with idempotent `Option::take()` cleanup on `RunEvent::ExitRequested`
  and `RunEvent::Exit`.
- `build_sidecar.py` refuses binaries < 1 MB.
- Tauri startup failures pop a native `MessageBoxW` instead of closing
  silently.

## Closes

Closes #98
Closes #99

## Test plan

- [x] `pytest` from `backend/` green (125 tests).
- [x] `pnpm test:run` from `frontend/` green.
- [x] `pnpm lint && pnpm exec tsc --noEmit && pnpm build` from `frontend/` green.
- [x] `cargo check` in `frontend/src-tauri/` green.
- [x] **Manual verification with packaged build (the bug only repro'd in release):**
  - [x] `python backend/scripts/build_sidecar.py && cd frontend && pnpm tauri build`, install MSI.
  - [x] **#99 invalid headers** → "Falta el header x-goog-authuser…" within 2 s.
  - [x] **#99 valid headers** → success toast, badge flips to "Conectado", `/api/health` returns `ytmusic:true`.
  - [x] **#98 clean close** — open and close 3× in a row → `Get-CimInstance Win32_Process -Filter "Name='spotify-to-ytmusic-server.exe'"` empty within 2 s every time.
  - [x] **#98 crash test** — kill `spotify-to-ytmusic.exe` from Task Manager → sidecar terminated immediately by the OS via the job object (no orphan).